### PR TITLE
fix: add trade deal and document tests to pass backend checkpoint

### DIFF
--- a/backend/src/trade-deals/trade-deals.service.spec.ts
+++ b/backend/src/trade-deals/trade-deals.service.spec.ts
@@ -1,0 +1,314 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { BadRequestException, NotFoundException, UnprocessableEntityException } from '@nestjs/common';
+import { TradeDealsService } from './trade-deals.service';
+import { TradeDeal } from './entities/trade-deal.entity';
+import { Document } from './entities/document.entity';
+import { ShipmentMilestone } from '../shipments/entities/shipment-milestone.entity';
+import { User } from '../auth/entities/user.entity';
+
+const mockFarmer = (): User => ({
+  id: 'farmer-uuid',
+  email: 'farmer@example.com',
+  passwordHash: 'hash',
+  role: 'farmer',
+  country: 'NG',
+  kycStatus: 'verified',
+  walletAddress: 'GFARMER123',
+  createdAt: new Date(),
+});
+
+const mockDeal = (): TradeDeal => ({
+  id: 'deal-uuid',
+  commodity: 'Cocoa',
+  quantity: 1000,
+  quantityUnit: 'kg',
+  totalValue: 5000,
+  tokenCount: 50,
+  tokenSymbol: 'COCOAdeal',
+  status: 'draft',
+  farmerId: 'farmer-uuid',
+  traderId: 'trader-uuid',
+  farmer: mockFarmer(),
+  trader: null as any,
+  escrowPublicKey: null,
+  escrowSecretKey: null,
+  issuerPublicKey: null,
+  totalInvested: 0,
+  deliveryDate: new Date('2026-12-01'),
+  stellarAssetTxId: null,
+  documents: [],
+  investments: [],
+  createdAt: new Date(),
+});
+
+describe('TradeDealsService', () => {
+  let service: TradeDealsService;
+  let tradeDealRepo: {
+    findOne: jest.Mock;
+    create: jest.Mock;
+    save: jest.Mock;
+    update: jest.Mock;
+  };
+  let documentRepo: { findOne: jest.Mock; create: jest.Mock; save: jest.Mock };
+  let milestoneRepo: { find: jest.Mock };
+  let userRepo: { findOne: jest.Mock };
+
+  beforeEach(async () => {
+    tradeDealRepo = {
+      findOne: jest.fn(),
+      create: jest.fn(),
+      save: jest.fn(),
+      update: jest.fn(),
+    };
+    documentRepo = { findOne: jest.fn(), create: jest.fn(), save: jest.fn() };
+    milestoneRepo = { find: jest.fn() };
+    userRepo = { findOne: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TradeDealsService,
+        { provide: getRepositoryToken(TradeDeal), useValue: tradeDealRepo },
+        { provide: getRepositoryToken(Document), useValue: documentRepo },
+        { provide: getRepositoryToken(ShipmentMilestone), useValue: milestoneRepo },
+        { provide: getRepositoryToken(User), useValue: userRepo },
+      ],
+    }).compile();
+
+    service = module.get<TradeDealsService>(TradeDealsService);
+  });
+
+  // ─── createDeal ───────────────────────────────────────────────────────────
+
+  describe('createDeal', () => {
+    const dto = {
+      commodity: 'Cocoa',
+      quantity: 1000,
+      quantity_unit: 'kg' as const,
+      total_value: 5000,
+      farmer_id: 'farmer-uuid',
+      delivery_date: '2026-12-01',
+    };
+
+    it('creates a draft trade deal with correct token count', async () => {
+      const farmer = mockFarmer();
+      userRepo.findOne.mockResolvedValue(farmer);
+      const deal = { ...mockDeal(), id: 'new-uuid' };
+      tradeDealRepo.create.mockReturnValue(deal);
+      tradeDealRepo.save
+        .mockResolvedValueOnce(deal)
+        .mockResolvedValueOnce({ ...deal, tokenSymbol: 'COCOAnew-' });
+
+      const result = await service.createDeal('trader-uuid', dto);
+
+      expect(result.status).toBe('draft');
+      expect(result.tokenCount).toBe(50); // floor(5000 / 100)
+    });
+
+    it('calculates token count as floor(total_value / 100)', async () => {
+      userRepo.findOne.mockResolvedValue(mockFarmer());
+      const deal = { ...mockDeal(), totalValue: 750, tokenCount: 7 };
+      tradeDealRepo.create.mockReturnValue(deal);
+      tradeDealRepo.save.mockResolvedValue(deal);
+
+      const result = await service.createDeal('trader-uuid', {
+        ...dto,
+        total_value: 750,
+      });
+
+      expect(result.tokenCount).toBe(7); // floor(750 / 100)
+    });
+
+    it('throws NotFoundException when farmer not found', async () => {
+      userRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.createDeal('trader-uuid', dto)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('throws BadRequestException when farmer_id belongs to non-farmer role', async () => {
+      userRepo.findOne.mockResolvedValue({ ...mockFarmer(), role: 'trader' });
+
+      await expect(service.createDeal('trader-uuid', dto)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('throws BadRequestException when total_value is less than 100', async () => {
+      userRepo.findOne.mockResolvedValue(mockFarmer());
+
+      await expect(
+        service.createDeal('trader-uuid', { ...dto, total_value: 50 }),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  // ─── publishDeal ──────────────────────────────────────────────────────────
+
+  describe('publishDeal', () => {
+    it('returns the deal when it has documents and is in draft status', async () => {
+      const deal = {
+        ...mockDeal(),
+        documents: [{ id: 'doc-1' }],
+      };
+      tradeDealRepo.findOne.mockResolvedValue(deal);
+
+      const result = await service.publishDeal('deal-uuid', 'trader-uuid');
+      expect(result.id).toBe('deal-uuid');
+    });
+
+    it('throws UnprocessableEntityException when deal has no documents', async () => {
+      tradeDealRepo.findOne.mockResolvedValue({ ...mockDeal(), documents: [] });
+
+      await expect(
+        service.publishDeal('deal-uuid', 'trader-uuid'),
+      ).rejects.toThrow(UnprocessableEntityException);
+    });
+
+    it('throws UnprocessableEntityException when deal is not in draft status', async () => {
+      tradeDealRepo.findOne.mockResolvedValue({
+        ...mockDeal(),
+        status: 'open',
+        documents: [{ id: 'doc-1' }],
+      });
+
+      await expect(
+        service.publishDeal('deal-uuid', 'trader-uuid'),
+      ).rejects.toThrow(UnprocessableEntityException);
+    });
+
+    it('throws NotFoundException when deal does not exist', async () => {
+      tradeDealRepo.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.publishDeal('nonexistent', 'trader-uuid'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws BadRequestException when caller is not the assigned trader', async () => {
+      tradeDealRepo.findOne.mockResolvedValue({
+        ...mockDeal(),
+        documents: [{ id: 'doc-1' }],
+      });
+
+      await expect(
+        service.publishDeal('deal-uuid', 'other-trader-uuid'),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  // ─── updateDealStatus ─────────────────────────────────────────────────────
+
+  describe('updateDealStatus', () => {
+    it('transitions deal status to open', async () => {
+      tradeDealRepo.update.mockResolvedValue({ affected: 1 });
+
+      await service.updateDealStatus('deal-uuid', 'open', 'stellar-tx-123');
+
+      expect(tradeDealRepo.update).toHaveBeenCalledWith('deal-uuid', {
+        status: 'open',
+        stellarAssetTxId: 'stellar-tx-123',
+      });
+    });
+
+    it('updates status without stellarAssetTxId when not provided', async () => {
+      tradeDealRepo.update.mockResolvedValue({ affected: 1 });
+
+      await service.updateDealStatus('deal-uuid', 'failed');
+
+      expect(tradeDealRepo.update).toHaveBeenCalledWith('deal-uuid', {
+        status: 'failed',
+      });
+    });
+  });
+
+  // ─── addDocument ──────────────────────────────────────────────────────────
+
+  describe('addDocument', () => {
+    const baseDto = {
+      tradeDealId: 'deal-uuid',
+      uploaderId: 'trader-uuid',
+      docType: 'bill_of_lading',
+      ipfsHash: 'QmXyz123abc',
+      storageUrl: 'https://ipfs.io/ipfs/QmXyz123abc',
+    };
+
+    it('saves a document with IPFS hash and returns it', async () => {
+      tradeDealRepo.findOne.mockResolvedValue(mockDeal());
+      const savedDoc = { id: 'doc-uuid', ...baseDto, stellarTxId: null };
+      documentRepo.create.mockReturnValue(savedDoc);
+      documentRepo.save.mockResolvedValue(savedDoc);
+
+      const result = await service.addDocument(baseDto);
+
+      expect(result.ipfsHash).toBe('QmXyz123abc');
+      expect(documentRepo.save).toHaveBeenCalled();
+    });
+
+    it('stores the Stellar tx ID when provided', async () => {
+      tradeDealRepo.findOne.mockResolvedValue(mockDeal());
+      const dto = { ...baseDto, stellarTxId: 'stellar-tx-abc' };
+      const savedDoc = { id: 'doc-uuid', ...dto };
+      documentRepo.create.mockReturnValue(savedDoc);
+      documentRepo.save.mockResolvedValue(savedDoc);
+
+      const result = await service.addDocument(dto);
+
+      expect(result.stellarTxId).toBe('stellar-tx-abc');
+    });
+
+    it('throws BadRequestException for invalid document type', async () => {
+      await expect(
+        service.addDocument({ ...baseDto, docType: 'invalid_type' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when file size exceeds 10 MB', async () => {
+      await expect(
+        service.addDocument({
+          ...baseDto,
+          fileSizeBytes: 11 * 1024 * 1024, // 11 MB
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('accepts file size exactly at the 10 MB limit', async () => {
+      tradeDealRepo.findOne.mockResolvedValue(mockDeal());
+      const dto = { ...baseDto, fileSizeBytes: 10 * 1024 * 1024 };
+      const savedDoc = { id: 'doc-uuid', ...baseDto, stellarTxId: null };
+      documentRepo.create.mockReturnValue(savedDoc);
+      documentRepo.save.mockResolvedValue(savedDoc);
+
+      await expect(service.addDocument(dto)).resolves.toBeDefined();
+    });
+
+    it('throws NotFoundException when trade deal does not exist', async () => {
+      tradeDealRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.addDocument(baseDto)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('accepts all valid document types', async () => {
+      const validTypes = [
+        'purchase_agreement',
+        'bill_of_lading',
+        'export_certificate',
+        'warehouse_receipt',
+      ];
+
+      for (const docType of validTypes) {
+        tradeDealRepo.findOne.mockResolvedValue(mockDeal());
+        const savedDoc = { id: 'doc-uuid', ...baseDto, docType, stellarTxId: null };
+        documentRepo.create.mockReturnValue(savedDoc);
+        documentRepo.save.mockResolvedValue(savedDoc);
+
+        await expect(
+          service.addDocument({ ...baseDto, docType }),
+        ).resolves.toBeDefined();
+      }
+    });
+  });
+});

--- a/backend/src/trade-deals/trade-deals.service.ts
+++ b/backend/src/trade-deals/trade-deals.service.ts
@@ -2,14 +2,33 @@ import {
   Injectable,
   NotFoundException,
   BadRequestException,
+  UnprocessableEntityException,
 } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
 import { TradeDeal, TradeDealStatus } from "./entities/trade-deal.entity";
-import { Document } from "./entities/document.entity";
+import { Document, DocumentType } from "./entities/document.entity";
 import { ShipmentMilestone } from "../shipments/entities/shipment-milestone.entity";
 import { CreateTradeDealDto } from "./dto/create-trade-deal.dto";
 import { User } from "../auth/entities/user.entity";
+
+const VALID_DOC_TYPES: DocumentType[] = [
+  'purchase_agreement',
+  'bill_of_lading',
+  'export_certificate',
+  'warehouse_receipt',
+];
+const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
+
+export interface AddDocumentDto {
+  tradeDealId: string;
+  uploaderId: string;
+  docType: string;
+  ipfsHash: string;
+  storageUrl: string;
+  stellarTxId?: string | null;
+  fileSizeBytes?: number;
+}
 
 @Injectable()
 export class TradeDealsService {
@@ -143,6 +162,72 @@ export class TradeDealsService {
         recordedAt: milestone.recordedAt,
       })),
     };
+  }
+
+  async publishDeal(dealId: string, traderId: string): Promise<TradeDeal> {
+    const deal = await this.tradeDealRepo.findOne({
+      where: { id: dealId },
+      relations: ['documents'],
+    });
+
+    if (!deal) {
+      throw new NotFoundException('Trade deal not found.');
+    }
+
+    if (deal.traderId !== traderId) {
+      throw new BadRequestException({
+        code: 'NOT_ASSIGNED_TRADER',
+        message: 'Only the assigned trader can publish this deal.',
+      });
+    }
+
+    if (deal.status !== 'draft') {
+      throw new UnprocessableEntityException({
+        code: 'DEAL_NOT_DRAFT',
+        message: 'Only draft deals can be published.',
+      });
+    }
+
+    if (!deal.documents || deal.documents.length === 0) {
+      throw new UnprocessableEntityException({
+        code: 'NO_DOCUMENTS',
+        message: 'At least one document must be uploaded before publishing.',
+      });
+    }
+
+    return deal;
+  }
+
+  async addDocument(dto: AddDocumentDto): Promise<Document> {
+    if (!VALID_DOC_TYPES.includes(dto.docType as DocumentType)) {
+      throw new BadRequestException({
+        code: 'INVALID_DOC_TYPE',
+        message: `Invalid document type. Must be one of: ${VALID_DOC_TYPES.join(', ')}.`,
+      });
+    }
+
+    if (dto.fileSizeBytes !== undefined && dto.fileSizeBytes > MAX_FILE_SIZE_BYTES) {
+      throw new BadRequestException({
+        code: 'FILE_TOO_LARGE',
+        message: `File size exceeds the maximum allowed size of ${MAX_FILE_SIZE_BYTES / (1024 * 1024)} MB.`,
+      });
+    }
+
+    const deal = await this.tradeDealRepo.findOne({ where: { id: dto.tradeDealId } });
+    if (!deal) {
+      throw new NotFoundException('Trade deal not found.');
+    }
+
+    const doc = this.documentRepo.create({
+      tradeDealId: dto.tradeDealId,
+      uploaderId: dto.uploaderId,
+      docType: dto.docType as DocumentType,
+      ipfsHash: dto.ipfsHash,
+      storageUrl: dto.storageUrl,
+      stellarTxId: dto.stellarTxId ?? null,
+    });
+
+    return this.documentRepo.save(doc);
   }
 
   private generateTokenSymbol(commodity: string, dealId: string): string {


### PR DESCRIPTION
CLoses #6 

## Summary

Backend test checkpoint to verify all tests pass after implementing trade deal creation/publishing (task 5) and document upload (task 6). No new feature code — only added missing service methods and tests to satisfy the checkpoint requirements.

## Changes

### `trade-deals.service.ts`
- Added `publishDeal()` — validates deal is in `draft` status, belongs to the calling trader, and has at least one document before allowing publish
- Added `addDocument()` — validates document type against allowed values, enforces a 10 MB file size limit, stores IPFS hash and optional Stellar tx ID

### `trade-deals.service.spec.ts` (new file)
- 19 tests covering the full surface of the two new methods plus `createDeal` and `updateDealStatus`

## Test Coverage

**Trade deal tests**
- Draft creation with correct token count (`floor(total_value / 100)`)
- Rejects `total_value < 100` (zero tokens)
- Rejects unknown `farmer_id` and non-farmer roles
- Publish rejected when no documents are attached
- Publish rejected when deal is not in `draft` status
- Publish rejected when caller is not the assigned trader
- Status transition to `open` with `stellarAssetTxId` recorded

**Document tests**
- File type validation — rejects invalid types, accepts all four valid types
- File size validation — rejects files over 10 MB, accepts files at exactly 10 MB
- IPFS hash stored correctly on save
- Stellar tx ID recorded when provided