### PR TITLE
feat: implement fundEscrow flow with RabbitMQ job and retry logic

### DIFF
--- a/backend/src/investments/investments.module.ts
+++ b/backend/src/investments/investments.module.ts
@@ -5,10 +5,10 @@ import { InvestmentsController } from './investments.controller';
 import { Investment } from './entities/investment.entity';
 import { TradeDeal } from '../trade-deals/entities/trade-deal.entity';
 import { StellarModule } from '../stellar/stellar.module';
-
+import { QueueModule } from '../queue/queue.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Investment, TradeDeal]), StellarModule],
+  imports: [TypeOrmModule.forFeature([Investment, TradeDeal]), StellarModule, QueueModule],
   controllers: [InvestmentsController],
   providers: [InvestmentsService],
   exports: [InvestmentsService],

--- a/backend/src/investments/investments.service.spec.ts
+++ b/backend/src/investments/investments.service.spec.ts
@@ -8,6 +8,7 @@ import { InvestmentsService } from "./investments.service";
 import { Investment, InvestmentStatus } from "./entities/investment.entity";
 import { TradeDeal } from "../trade-deals/entities/trade-deal.entity";
 import { StellarService } from "../stellar/stellar.service";
+import { QueueService } from "../queue/queue.service";
 import { CreateInvestmentDto } from "./dto/create-investment.dto";
 
 const mockTradeDeal = (): TradeDeal => ({
@@ -54,9 +55,11 @@ describe("InvestmentsService", () => {
     find: jest.Mock;
     create: jest.Mock;
     save: jest.Mock;
+    update: jest.Mock;
   };
   let tradeDealRepo: { findOne: jest.Mock; update: jest.Mock };
   let stellarService: { fundEscrow: jest.MockedFunction<any> };
+  let queueService: { enqueueInvestmentFund: jest.MockedFunction<any> };
 
   beforeEach(async () => {
     investmentRepo = {
@@ -64,9 +67,11 @@ describe("InvestmentsService", () => {
       find: jest.fn(),
       create: jest.fn(),
       save: jest.fn(),
+      update: jest.fn(),
     };
     tradeDealRepo = { findOne: jest.fn(), update: jest.fn() };
     stellarService = { fundEscrow: jest.fn() };
+    queueService = { enqueueInvestmentFund: jest.fn().mockResolvedValue(undefined) };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -74,6 +79,7 @@ describe("InvestmentsService", () => {
         { provide: getRepositoryToken(Investment), useValue: investmentRepo },
         { provide: getRepositoryToken(TradeDeal), useValue: tradeDealRepo },
         { provide: StellarService, useValue: stellarService },
+        { provide: QueueService, useValue: queueService },
       ],
     }).compile();
 
@@ -263,6 +269,9 @@ describe("InvestmentsService", () => {
         "escrow-pub-key",
         "investor-wallet-address",
         "1000",
+        "escrow-secret",
+        "COFFEE-001",
+        100,
       );
 
       expect(result.stellarTxId).toBe("stellar-tx-456");
@@ -272,6 +281,52 @@ describe("InvestmentsService", () => {
           stellarTxId: "stellar-tx-456",
         }),
       );
+    });
+
+    it("enqueues investment.fund job when signedXdr is provided", async () => {
+      const investment = {
+        ...mockInvestment(),
+        status: InvestmentStatus.PENDING,
+        tradeDeal: mockTradeDeal(),
+      };
+
+      investmentRepo.findOne.mockResolvedValue(investment);
+
+      const result = await service.fundEscrow(
+        "inv-1",
+        "investor-wallet-address",
+        "signed-xdr-payload",
+      );
+
+      expect(queueService.enqueueInvestmentFund).toHaveBeenCalledWith(
+        expect.objectContaining({
+          investmentId: "inv-1",
+          signedXdr: "signed-xdr-payload",
+          escrowPublicKey: "escrow-pub-key",
+          investorWallet: "investor-wallet-address",
+          tokenAmount: 100,
+          amountUsd: 1000,
+        }),
+      );
+      expect(result.stellarTxId).toBe("queued");
+    });
+
+    it("does NOT modify total_invested when Stellar fails", async () => {
+      const investment = {
+        ...mockInvestment(),
+        status: InvestmentStatus.PENDING,
+        tradeDeal: mockTradeDeal(),
+      };
+
+      investmentRepo.findOne.mockResolvedValue(investment);
+      stellarService.fundEscrow.mockRejectedValue(new Error("Stellar network error"));
+
+      await expect(
+        service.fundEscrow("inv-1", "investor-wallet-address"),
+      ).rejects.toThrow("Stellar network error");
+
+      // total_invested must NOT be updated
+      expect(tradeDealRepo.update).not.toHaveBeenCalled();
     });
 
     it("throws error when investment not found", async () => {
@@ -294,6 +349,19 @@ describe("InvestmentsService", () => {
       await expect(
         service.fundEscrow("inv-1", "wallet-address"),
       ).rejects.toThrow(UnprocessableEntityException);
+    });
+  });
+
+  describe("markInvestmentFailed", () => {
+    it("sets investment status to failed without touching total_invested", async () => {
+      investmentRepo.update.mockResolvedValue({ affected: 1 });
+
+      await service.markInvestmentFailed("inv-1");
+
+      expect(investmentRepo.update).toHaveBeenCalledWith("inv-1", {
+        status: InvestmentStatus.FAILED,
+      });
+      expect(tradeDealRepo.update).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/src/investments/investments.service.ts
+++ b/backend/src/investments/investments.service.ts
@@ -5,11 +5,12 @@ import {
   ForbiddenException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, DataSource } from 'typeorm';
 import { Investment, InvestmentStatus } from './entities/investment.entity';
 import { CreateInvestmentDto } from './dto/create-investment.dto';
 import { TradeDeal, TradeDealStatus } from '../trade-deals/entities/trade-deal.entity';
 import { StellarService } from '../stellar/stellar.service';
+import { QueueService } from '../queue/queue.service';
 
 @Injectable()
 export class InvestmentsService {
@@ -19,6 +20,7 @@ export class InvestmentsService {
     @InjectRepository(TradeDeal)
     private readonly tradeDealRepo: Repository<TradeDeal>,
     private readonly stellarService: StellarService,
+    private readonly queueService: QueueService,
   ) {}
 
   async createInvestment(
@@ -115,7 +117,7 @@ export class InvestmentsService {
 
     await this.investmentRepo.save(investment);
 
-    // Update total invested on the trade deal
+    // Update total invested on the trade deal using confirmed investments sum
     const tradeDeal = investment.tradeDeal;
     const confirmedInvestments = await this.investmentRepo.find({
       where: { 
@@ -143,9 +145,16 @@ export class InvestmentsService {
     return investment;
   }
 
+  async markInvestmentFailed(investmentId: string): Promise<void> {
+    await this.investmentRepo.update(investmentId, {
+      status: InvestmentStatus.FAILED,
+    });
+  }
+
   async fundEscrow(
     investmentId: string,
     investorWalletAddress: string,
+    signedXdr?: string,
   ): Promise<{ stellarTxId: string }> {
     const investment = await this.investmentRepo.findOne({
       where: { id: investmentId },
@@ -163,21 +172,41 @@ export class InvestmentsService {
       });
     }
 
-    if (!investment.tradeDeal.escrowPublicKey) {
+    const deal = investment.tradeDeal;
+
+    if (!deal.escrowPublicKey) {
       throw new UnprocessableEntityException({
         code: 'NO_ESCROW_ACCOUNT',
         message: 'Trade deal does not have an escrow account.',
       });
     }
 
-    // Fund the escrow account via Stellar
+    // If a signed XDR is provided (investor signed via Freighter), enqueue async job
+    if (signedXdr) {
+      await this.queueService.enqueueInvestmentFund({
+        investmentId,
+        signedXdr,
+        escrowPublicKey: deal.escrowPublicKey,
+        encryptedEscrowSecret: deal.escrowSecretKey ?? '',
+        assetCode: deal.tokenSymbol,
+        tokenAmount: investment.tokenAmount,
+        investorWallet: investorWalletAddress,
+        amountUsd: Number(investment.amountUsd),
+      });
+      // Return a placeholder — actual txId will be set when job completes
+      return { stellarTxId: 'queued' };
+    }
+
+    // Synchronous path (backend-signed, used in tests / MVP fallback)
     const stellarTxId = await this.stellarService.fundEscrow(
-      investment.tradeDeal.escrowPublicKey,
+      deal.escrowPublicKey,
       investorWalletAddress,
       investment.amountUsd.toString(),
+      deal.escrowSecretKey ?? undefined,
+      deal.tokenSymbol,
+      investment.tokenAmount,
     );
 
-    // Auto-confirm the investment after successful funding
     await this.confirmInvestment(investmentId, stellarTxId);
 
     return { stellarTxId };

--- a/backend/src/queue/queue.module.ts
+++ b/backend/src/queue/queue.module.ts
@@ -5,6 +5,7 @@ import { QueueService } from './queue.service';
 import { QueueProcessor } from './queue.processor';
 import { TradeDealsModule } from '../trade-deals/trade-deals.module';
 import { StellarModule } from '../stellar/stellar.module';
+import { InvestmentsModule } from '../investments/investments.module';
 
 export const QUEUE_SERVICE = 'QUEUE_SERVICE';
 
@@ -28,6 +29,7 @@ export const QUEUE_SERVICE = 'QUEUE_SERVICE';
     ]),
     TradeDealsModule,
     StellarModule,
+    InvestmentsModule,
   ],
   providers: [QueueService, QueueProcessor],
   exports: [QueueService, ClientsModule],

--- a/backend/src/queue/queue.processor.ts
+++ b/backend/src/queue/queue.processor.ts
@@ -2,6 +2,7 @@ import { Controller, Logger } from '@nestjs/common';
 import { Ctx, EventPattern, Payload, RmqContext } from '@nestjs/microservices';
 import { StellarService } from '../stellar/stellar.service';
 import { TradeDealsService } from '../trade-deals/trade-deals.service';
+import { InvestmentsService } from '../investments/investments.service';
 
 interface DealPublishPayload {
   dealId: string;
@@ -11,6 +12,19 @@ interface DealPublishPayload {
   tokenCount: number;
 }
 
+interface InvestmentFundPayload {
+  investmentId: string;
+  signedXdr: string;
+  escrowPublicKey: string;
+  encryptedEscrowSecret: string;
+  assetCode: string;
+  tokenAmount: number;
+  investorWallet: string;
+  amountUsd: number;
+}
+
+const MAX_RETRIES = 3;
+
 @Controller()
 export class QueueProcessor {
   private readonly logger = new Logger(QueueProcessor.name);
@@ -18,6 +32,7 @@ export class QueueProcessor {
   constructor(
     private readonly stellarService: StellarService,
     private readonly tradeDealsService: TradeDealsService,
+    private readonly investmentsService: InvestmentsService,
   ) {}
 
   @EventPattern('deal.publish')
@@ -60,5 +75,64 @@ export class QueueProcessor {
     const channel = context.getChannelRef();
     const originalMsg = context.getMessage();
     channel.ack(originalMsg);
+  }
+
+  @EventPattern('investment.fund')
+  async handleInvestmentFund(
+    @Payload() data: InvestmentFundPayload,
+    @Ctx() context: RmqContext,
+  ) {
+    this.logger.log(`Processing investment.fund for investment ${data.investmentId}`);
+
+    let attempt = 0;
+    let lastError: Error | null = null;
+
+    while (attempt < MAX_RETRIES) {
+      try {
+        // Submit the investor-signed XDR to Stellar
+        const result = await this.stellarService.submitTransaction(data.signedXdr);
+        const stellarTxId: string = result.hash;
+
+        // Transfer Trade_Tokens from escrow to investor
+        const escrowSecret = this.stellarService.decryptSecret(data.encryptedEscrowSecret);
+        await (this.stellarService as any).transferTokensToInvestor(
+          escrowSecret,
+          data.escrowPublicKey,
+          data.investorWallet,
+          data.assetCode,
+          data.tokenAmount,
+        );
+
+        // Confirm investment and increment total_invested
+        await this.investmentsService.confirmInvestment(data.investmentId, stellarTxId);
+
+        this.logger.log(
+          `Successfully funded investment ${data.investmentId} with txId ${stellarTxId}`,
+        );
+
+        const channel = context.getChannelRef();
+        channel.ack(context.getMessage());
+        return;
+      } catch (error) {
+        attempt++;
+        lastError = error;
+        this.logger.warn(
+          `investment.fund attempt ${attempt}/${MAX_RETRIES} failed for ${data.investmentId}: ${error.message}`,
+        );
+
+        if (attempt < MAX_RETRIES) {
+          await new Promise((r) => setTimeout(r, 500 * attempt)); // exponential backoff
+        }
+      }
+    }
+
+    // All retries exhausted — mark investment as failed
+    this.logger.error(
+      `investment.fund permanently failed for ${data.investmentId} after ${MAX_RETRIES} attempts: ${lastError?.message}`,
+    );
+    await this.investmentsService.markInvestmentFailed(data.investmentId);
+
+    const channel = context.getChannelRef();
+    channel.ack(context.getMessage());
   }
 }

--- a/backend/src/queue/queue.service.ts
+++ b/backend/src/queue/queue.service.ts
@@ -24,4 +24,20 @@ export class QueueService {
   async enqueueDealDelivered(tradeDealId: string): Promise<void> {
     await this.emit('deal.delivered', { tradeDealId });
   }
+
+  /**
+   * Enqueue an investment.fund job to submit the signed XDR and confirm investment
+   */
+  async enqueueInvestmentFund(payload: {
+    investmentId: string;
+    signedXdr: string;
+    escrowPublicKey: string;
+    encryptedEscrowSecret: string;
+    assetCode: string;
+    tokenAmount: number;
+    investorWallet: string;
+    amountUsd: number;
+  }): Promise<void> {
+    await this.emit('investment.fund', payload);
+  }
 }

--- a/backend/src/stellar/stellar.service.ts
+++ b/backend/src/stellar/stellar.service.ts
@@ -10,6 +10,7 @@ import {
   BASE_FEE,
   Memo,
 } from 'stellar-sdk';
+import { createDecipheriv, createCipheriv, randomBytes } from 'crypto';
 
 export interface InvestorShare {
   walletAddress: string;
@@ -185,6 +186,9 @@ export class StellarService {
     escrowPublicKey: string,
     investorWallet: string,
     amountUSD: string,
+    encryptedEscrowSecret?: string,
+    assetCode?: string,
+    tokenAmount?: number,
   ): Promise<string> {
     // In MVP, we use XLM as the payment asset (1 XLM ≈ $1 for testnet simplicity)
     // Production would use USDC
@@ -207,7 +211,85 @@ export class StellarService {
     // Note: in production the investor signs this via their wallet (Freighter/Albedo)
     // For backend-initiated flows, we'd need the investor's secret — omitted here
     const result = await this.server.submitTransaction(tx);
-    return (result as any).hash as string;
+    const paymentTxId = (result as any).hash as string;
+
+    // If escrow secret and asset info provided, transfer Trade_Tokens to investor
+    if (encryptedEscrowSecret && assetCode && tokenAmount !== undefined) {
+      const escrowSecret = this.decryptSecret(encryptedEscrowSecret);
+      await this.transferTokensToInvestor(
+        escrowSecret,
+        escrowPublicKey,
+        investorWallet,
+        assetCode,
+        tokenAmount,
+      );
+    }
+
+    return paymentTxId;
+  }
+
+  /**
+   * Transfers Trade_Tokens from escrow account to investor wallet.
+   */
+  private async transferTokensToInvestor(
+    escrowSecret: string,
+    escrowPublicKey: string,
+    investorWallet: string,
+    assetCode: string,
+    tokenAmount: number,
+  ): Promise<string> {
+    const escrowKeypair = Keypair.fromSecret(escrowSecret);
+    const escrowAccount = await this.server.loadAccount(escrowPublicKey);
+
+    const tradeToken = new Asset(assetCode, escrowPublicKey);
+
+    const tx = new TransactionBuilder(escrowAccount, {
+      fee: BASE_FEE,
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(
+        Operation.payment({
+          destination: investorWallet,
+          asset: tradeToken,
+          amount: tokenAmount.toFixed(7),
+        }),
+      )
+      .setTimeout(30)
+      .build();
+
+    tx.sign(escrowKeypair);
+
+    const result = await this.server.submitTransaction(tx);
+    const txId = (result as any).hash as string;
+    this.logger.log(`Transferred ${tokenAmount} ${assetCode} tokens to ${investorWallet}. txId=${txId}`);
+    return txId;
+  }
+
+  /**
+   * Encrypts a secret key using AES-256-CBC with the ENCRYPTION_KEY env var.
+   */
+  encryptSecret(secret: string): string {
+    const key = Buffer.from(
+      this.config.get<string>('ENCRYPTION_KEY', '').padEnd(32, '0').slice(0, 32),
+    );
+    const iv = randomBytes(16);
+    const cipher = createCipheriv('aes-256-cbc', key, iv);
+    const encrypted = Buffer.concat([cipher.update(secret, 'utf8'), cipher.final()]);
+    return `${iv.toString('hex')}:${encrypted.toString('hex')}`;
+  }
+
+  /**
+   * Decrypts a secret key encrypted by encryptSecret().
+   */
+  decryptSecret(encryptedSecret: string): string {
+    const key = Buffer.from(
+      this.config.get<string>('ENCRYPTION_KEY', '').padEnd(32, '0').slice(0, 32),
+    );
+    const [ivHex, encryptedHex] = encryptedSecret.split(':');
+    const iv = Buffer.from(ivHex, 'hex');
+    const encrypted = Buffer.from(encryptedHex, 'hex');
+    const decipher = createDecipheriv('aes-256-cbc', key, iv);
+    return Buffer.concat([decipher.update(encrypted), decipher.final()]).toString('utf8');
   }
 
   /**


### PR DESCRIPTION
Closes #8 

## Summary

Implements the full `fundEscrow` investment flow on Stellar, wired through a RabbitMQ async job with retry logic. Covers requirements 4.2, 4.3, 4.5, and 4.6 — escrow funding, Trade_Token transfer, failure isolation, and `total_invested` increment.

## Changes

### `backend/src/stellar/stellar.service.ts`
- `fundEscrow` now accepts optional `encryptedEscrowSecret`, `assetCode`, and `tokenAmount` — after the investor payment lands, it decrypts the escrow secret and transfers Trade_Tokens from the escrow account to the investor's wallet
- Added private `transferTokensToInvestor` — builds and signs a Stellar payment operation from the escrow account to the investor using the custom Trade_Token asset
- Added `encryptSecret` / `decryptSecret` — AES-256-CBC helpers using the `ENCRYPTION_KEY` env var; used to encrypt escrow secret keys at rest and decrypt them before signing

### `backend/src/investments/investments.service.ts`
- Injected `QueueService` — pending investment creation now enqueues an `investment.fund` job when a `signedXdr` is provided (investor signed via Freighter on the frontend)
- Synchronous Stellar path retained as MVP fallback when no XDR is provided
- Added `markInvestmentFailed` — sets investment status to `failed` without touching `trade_deal.total_invested`, satisfying requirement 4.5

### `backend/src/queue/queue.service.ts`
- Added `enqueueInvestmentFund` — emits `investment.fund` event with full job payload (investmentId, signedXdr, escrow keys, asset info, wallet addresses)

### `backend/src/queue/queue.processor.ts`
- Added `investment.fund` event handler with up to 3 retry attempts and exponential backoff (500ms × attempt)
- On success: submits signed XDR, transfers tokens, calls `confirmInvestment`
- On exhaustion: calls `markInvestmentFailed` and acks the message to prevent infinite requeue

### `backend/src/queue/queue.module.ts`
- Imports `InvestmentsModule` so `QueueProcessor` can inject `InvestmentsService`

### `backend/src/investments/investments.module.ts`
- Imports `QueueModule` so `InvestmentsService` can inject `QueueService`

## Test Coverage

- Stellar success path — escrow funded, tokens transferred, investment confirmed, `total_invested` incremented
- Signed XDR path — `investment.fund` job enqueued with correct payload, returns `{ stellarTxId: 'queued' }`
- Stellar failure — `total_invested` is NOT modified (req 4.5)
- `markInvestmentFailed` — sets status to `failed`, no `tradeDeal` update
- Existing tests for `createInvestment`, `confirmInvestment`, `getInvestments*` all passing