### PR TITLE
feat: implement POST /documents endpoint with IPFS upload and Stellar memo anchoring

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -40,6 +40,7 @@
         "@types/amqplib": "^0.10.0",
         "@types/bcrypt": "^5.0.0",
         "@types/jest": "^29.5.0",
+        "@types/multer": "^2.1.0",
         "@types/node": "^20.0.0",
         "@types/passport-jwt": "^3.0.0",
         "@types/passport-local": "^1.0.0",
@@ -3710,6 +3711,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/multer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.1.0.tgz",
+      "integrity": "sha512-zYZb0+nJhOHtPpGDb3vqPjwpdeGlGC157VpkqNQL+UU2qwoacoQ7MpsAmUptI/0Oa127X32JzWDqQVEXp2RcIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
       }
     },
     "node_modules/@types/node": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -48,6 +48,7 @@
     "@types/amqplib": "^0.10.0",
     "@types/bcrypt": "^5.0.0",
     "@types/jest": "^29.5.0",
+    "@types/multer": "^2.1.0",
     "@types/node": "^20.0.0",
     "@types/passport-jwt": "^3.0.0",
     "@types/passport-local": "^1.0.0",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -10,6 +10,7 @@ import { UsersModule } from "./users/users.module";
 import { InvestmentsModule } from "./investments/investments.module";
 import { EscrowModule } from "./escrow/escrow.module";
 import { StorageModule } from "./storage/storage.module";
+import { DocumentsModule } from "./documents/documents.module";
 
 @Module({
   imports: [
@@ -29,6 +30,7 @@ import { StorageModule } from "./storage/storage.module";
     InvestmentsModule,
     EscrowModule,
     StorageModule,
+    DocumentsModule,
   ],
 })
 export class AppModule {}

--- a/backend/src/documents/documents.controller.ts
+++ b/backend/src/documents/documents.controller.ts
@@ -1,0 +1,58 @@
+import {
+  Controller,
+  Post,
+  UseGuards,
+  UseInterceptors,
+  UploadedFile,
+  Body,
+  Request,
+  BadRequestException,
+} from "@nestjs/common";
+import { FileInterceptor } from "@nestjs/platform-express";
+import { AuthGuard } from "@nestjs/passport";
+import { DocumentsService } from "./documents.service";
+import { User } from "../auth/entities/user.entity";
+
+interface AuthRequest extends Request {
+  user: User;
+}
+
+const ALLOWED_TYPES = ["application/pdf", "image/png", "image/jpeg"];
+const MAX_FILE_SIZE = 10 * 1024 * 1024;
+
+@Controller("documents")
+export class DocumentsController {
+  constructor(private readonly documentsService: DocumentsService) {}
+
+  @Post()
+  @UseGuards(AuthGuard("jwt"))
+  @UseInterceptors(FileInterceptor("file"))
+  async uploadDocument(
+    @UploadedFile() file: Express.Multer.File,
+    @Body() body: { doc_type: string; trade_deal_id: string },
+    @Request() req: AuthRequest,
+  ) {
+    if (!file) {
+      throw new BadRequestException("File is required");
+    }
+
+    if (file.size > 10 * 1024 * 1024) {
+      throw new BadRequestException("File exceeds 10 MB limit");
+    }
+
+    if (
+      !["application/pdf", "image/png", "image/jpeg"].includes(file.mimetype)
+    ) {
+      throw new BadRequestException(
+        "Unsupported file type. Only PDF, PNG, JPEG allowed",
+      );
+    }
+
+    return this.documentsService.handleUpload({
+      file,
+      docType: body.doc_type,
+      tradeDealId: body.trade_deal_id,
+      userId: req.user.id,
+    });
+  }
+}

--- a/backend/src/documents/documents.module.ts
+++ b/backend/src/documents/documents.module.ts
@@ -1,0 +1,13 @@
+import { Module } from "@nestjs/common";
+import { DocumentsController } from "./documents.controller";
+import { DocumentsService } from "./documents.service";
+import { StorageModule } from "../storage/storage.module";
+import { StellarModule } from "../stellar/stellar.module";
+import { TradeDealsModule } from "../trade-deals/trade-deals.module";
+
+@Module({
+  imports: [StorageModule, StellarModule, TradeDealsModule],
+  controllers: [DocumentsController],
+  providers: [DocumentsService],
+})
+export class DocumentsModule {}

--- a/backend/src/documents/documents.service.ts
+++ b/backend/src/documents/documents.service.ts
@@ -1,0 +1,61 @@
+import { Injectable } from "@nestjs/common";
+import { StorageService } from "../storage/storage.service";
+import { StellarService } from "../stellar/stellar.service";
+import { TradeDealsService } from "../trade-deals/trade-deals.service";
+import { ConfigService } from "@nestjs/config";
+
+@Injectable()
+export class DocumentsService {
+  constructor(
+    private readonly storageService: StorageService,
+    private readonly stellarService: StellarService,
+    private readonly tradeDealsService: TradeDealsService,
+    private readonly config: ConfigService,
+  ) {}
+
+  async handleUpload({
+    file,
+    docType,
+    tradeDealId,
+    userId,
+  }: {
+    file: Express.Multer.File;
+    docType: string;
+    tradeDealId: string;
+    userId: string;
+  }) {
+    // 1. Upload (IPFS → S3 fallback handled internally)
+    const { hash, url } = await this.storageService.upload(
+      file.buffer,
+      file.mimetype,
+    );
+
+    // 2. Build Stellar memo (28 bytes safe)
+    const memo = this.buildMemo(tradeDealId, hash);
+
+    const signerSecret = this.config.get<string>("STELLAR_PLATFORM_SECRET", "");
+
+    const stellarTxId = await this.stellarService.recordMemo(
+      memo,
+      signerSecret,
+    );
+
+    // 3. Persist using existing logic (VERY IMPORTANT)
+    return this.tradeDealsService.addDocument({
+      tradeDealId,
+      uploaderId: userId,
+      docType,
+      ipfsHash: hash,
+      storageUrl: url,
+      stellarTxId,
+      fileSizeBytes: file.size,
+    });
+  }
+
+  private buildMemo(tradeDealId: string, hash: string): string {
+    const shortDeal = tradeDealId.replace(/-/g, "").slice(0, 6);
+    const shortHash = hash.slice(0, 10);
+
+    return `AGRIC:DOC:${shortDeal}:${shortHash}`.slice(0, 28);
+  }
+}


### PR DESCRIPTION
## Summary

Implements the `POST /documents` endpoint for uploading trade documents with validation, storage, and on-chain anchoring.

## Key Features

- Accepts `multipart/form-data` with `file`, `doc_type`, and `trade_deal_id`
- Validates file size (max 10 MB) and MIME type (PDF, PNG, JPEG)
- Uploads files via `StorageService` (IPFS with S3 fallback)
- Anchors document hash on Stellar using memo transactions
- Persists document metadata including `ipfs_hash`, `storage_url`, and `stellar_tx_id`
- Associates document with trade deal and uploader

## Implementation Notes

- Reuses existing `TradeDealsService.addDocument()` for validation and persistence
- Stellar memo format: `AGRIC:DOC:{deal_short}:{hash_short}` (≤28 bytes)
- Uses platform signer for memo anchoring (MVP-safe)

## Result

Returns `201 Created` with the stored document object.

Closes #5