### PR TITLE
fix(auth): validate Stellar public key on POST /auth/wallet

### DIFF
--- a/PULL_REQUEST.md
+++ b/PULL_REQUEST.md
@@ -1,0 +1,101 @@
+# fix(auth): validate Stellar public key on wallet link
+
+Closes #<issue-number>
+
+## Problem
+
+`AuthService.linkWallet()` accepted any string as `walletAddress` with no
+format validation. An invalid value stored in the database would silently pass
+all upstream checks (the `walletAddress` truthy-check in `EscrowService`) and
+only fail deep inside `StellarService.releaseEscrow()` when
+`Operation.payment({ destination: "<invalid>" })` throws — after the deal is
+already in `delivered` state, escrow funds are locked, and the farmer is never
+paid.
+
+## What changed
+
+### `backend/src/auth/dto/wallet.dto.ts`
+- Added `@IsStellarPublicKey()` custom decorator using `registerDecorator` from
+  `class-validator`. It calls `Keypair.fromPublicKey(value)` from `stellar-sdk`
+  and returns `false` if it throws — the same validation the SDK uses internally.
+- Added `@ApiProperty` with description and example for Swagger documentation.
+- Kept existing `@IsString()` as a first-pass type guard.
+
+### `backend/src/main.ts`
+- Added `exceptionFactory` to the global `ValidationPipe` so that an
+  `isStellarPublicKey` constraint failure returns the shaped error body the
+  issue requires:
+  ```json
+  { "code": "INVALID_WALLET_ADDRESS", "message": "walletAddress must be a valid Stellar public key." }
+  ```
+  All other validation errors continue to use the default NestJS format.
+- Wired up `SwaggerModule` at `/api/docs` so `@ApiProperty` decorators are
+  served.
+
+### `backend/src/auth/dto/wallet.dto.spec.ts` *(new)*
+Unit tests for the custom validator using `class-validator`'s `validate()`
+directly:
+- valid Stellar public key → 0 errors
+- plain string → `isStellarPublicKey` constraint error
+- Stellar secret key (`S...`) → constraint error
+- empty string → error
+- key truncated by 1 char → constraint error
+
+### `backend/src/auth/auth.service.spec.ts`
+- Replaced the invalid test key `'GABC123'` in the `linkWallet` test with a
+  real `stellar-sdk v12` generated public key.
+- Added a second `linkWallet` test: `NotFoundException` when user does not
+  exist.
+
+### `backend/src/database/migrations/1699900000007-ValidateWalletAddresses.ts` *(new)*
+Two-step migration:
+1. **Nullifies** any existing `wallet_address` rows that do not match
+   `^G[A-Z2-7]{55}$` (the Stellar public key regex). Affected users will need
+   to re-link their wallet — safer than blocking the migration or deleting
+   accounts.
+2. **Adds a `CHECK` constraint** (`chk_wallet_address_stellar`) on the column
+   so the database itself enforces the format going forward, independent of the
+   application layer.
+
+`down()` drops the constraint only (the nullified rows are not restored — they
+were already invalid).
+
+## How to migrate
+
+```bash
+cd backend
+npm run migration:run
+```
+
+The migration is safe to run against a live database. The `UPDATE` runs first
+(nullifying bad rows), then the `ALTER TABLE` adds the constraint. If no rows
+have invalid wallet addresses the `UPDATE` is a no-op.
+
+To verify before running:
+
+```sql
+-- Preview which rows would be nullified
+SELECT id, email, wallet_address
+FROM users
+WHERE wallet_address IS NOT NULL
+  AND wallet_address !~ '^G[A-Z2-7]{55}$';
+```
+
+## Testing
+
+```bash
+cd backend
+npm test -- --testPathPattern="wallet.dto|auth.service" --no-coverage
+```
+
+Expected: **13 tests pass**, 0 failures.
+
+## Acceptance criteria
+
+| Criterion | How it is met |
+|---|---|
+| `POST /auth/wallet` with non-Stellar string → 400 `INVALID_WALLET_ADDRESS` | `@IsStellarPublicKey()` on DTO + `exceptionFactory` in `main.ts` |
+| `POST /auth/wallet` with valid `G...` key → succeeds | `Keypair.fromPublicKey()` only passes for real keys |
+| Custom validator unit-tested with valid and invalid inputs | `wallet.dto.spec.ts` — 5 cases |
+| `WalletDto` documented in Swagger spec | `@ApiProperty` on field + `SwaggerModule` wired at `/api/docs` |
+| Existing invalid wallet addresses handled | Migration 1699900000007 nullifies bad rows + adds DB CHECK constraint |

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,6 +16,7 @@
         "@nestjs/microservices": "^10.0.0",
         "@nestjs/passport": "^10.0.0",
         "@nestjs/platform-express": "^10.0.0",
+        "@nestjs/swagger": "^11.4.1",
         "@nestjs/typeorm": "^10.0.0",
         "amqp-connection-manager": "^4.1.14",
         "amqplib": "^0.10.3",
@@ -30,6 +31,7 @@
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.0",
         "stellar-sdk": "^12.0.0",
+        "swagger-ui-express": "^5.0.1",
         "typeorm": "^0.3.17",
         "uuid": "^9.0.0"
       },
@@ -1685,7 +1687,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -1698,7 +1700,7 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -2353,7 +2355,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -2374,7 +2376,7 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -2429,6 +2431,12 @@
       "bin": {
         "node-pre-gyp": "bin/node-pre-gyp"
       }
+    },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
+      "integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
+      "license": "MIT"
     },
     "node_modules/@nestjs/cli": {
       "version": "10.4.9",
@@ -2586,6 +2594,26 @@
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0"
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.1.tgz",
+      "integrity": "sha512-SCCoMEJ6jdeI5h/N+KCVF1+pmg/hmEkNA5nHTS8Gvww7T/LCl4o1gFLinw2iQ60w7slFkszHcGLKGdazVI4F8A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0 || ^0.15.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/microservices": {
       "version": "10.4.22",
       "resolved": "https://registry.npmjs.org/@nestjs/microservices/-/microservices-10.4.22.tgz",
@@ -2698,6 +2726,55 @@
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "11.4.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.4.1.tgz",
+      "integrity": "sha512-GuGzs8F1Cb3n+eEarmOqB4nt2ai+x4XGOYUXNYplOtDeB59DaFY5E16bsHsBWXiWgD1ywbyKQ5OVv02bQtB1Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.16.0",
+        "@nestjs/mapped-types": "2.1.1",
+        "js-yaml": "4.1.1",
+        "lodash": "4.18.1",
+        "path-to-regexp": "8.4.2",
+        "swagger-ui-dist": "5.32.4"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^8.0.0 || ^9.0.0",
+        "@nestjs/common": "^11.0.1",
+        "@nestjs/core": "^11.0.1",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/swagger/node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/@nestjs/swagger/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/@nestjs/testing": {
       "version": "10.4.22",
@@ -2821,6 +2898,13 @@
       "funding": {
         "url": "https://opencollective.com/pkgr"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
@@ -3686,28 +3770,28 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
       "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/amqplib": {
@@ -4556,7 +4640,7 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -4579,7 +4663,7 @@
       "version": "8.3.5",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
       "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.11.0"
@@ -4846,14 +4930,13 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-flatten": {
@@ -5881,7 +5964,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -6031,7 +6114,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
       "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -8775,7 +8858,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -9121,7 +9203,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/makeerror": {
@@ -11097,6 +11179,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.4",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.4.tgz",
+      "integrity": "sha512-0AADFFQNJzExEN49SrD/34Nn9cxNxVLiydYl2MBwSZFPVXNkVwC/EFAjoezGGqE8oDegiDC+p47t8lKObCinMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
     "node_modules/symbol-observable": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
@@ -11581,7 +11687,7 @@
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -11972,7 +12078,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -12134,7 +12240,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
@@ -12465,7 +12571,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"

--- a/backend/package.json
+++ b/backend/package.json
@@ -24,6 +24,7 @@
     "@nestjs/microservices": "^10.0.0",
     "@nestjs/passport": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/swagger": "^11.4.1",
     "@nestjs/typeorm": "^10.0.0",
     "amqp-connection-manager": "^4.1.14",
     "amqplib": "^0.10.3",
@@ -38,6 +39,7 @@
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.0",
     "stellar-sdk": "^12.0.0",
+    "swagger-ui-express": "^5.0.1",
     "typeorm": "^0.3.17",
     "uuid": "^9.0.0"
   },

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { JwtService } from '@nestjs/jwt';
-import { ConflictException, UnauthorizedException } from '@nestjs/common';
+import { ConflictException, NotFoundException, UnauthorizedException } from '@nestjs/common';
 import * as bcrypt from 'bcrypt';
 import { AuthService } from './auth.service';
 import { User } from './entities/user.entity';
@@ -104,13 +104,22 @@ describe('AuthService', () => {
   });
 
   describe('linkWallet', () => {
-    it('updates wallet address', async () => {
+    const VALID_STELLAR_KEY = 'GB5HA3VWSBWS47VIKMOOMTMA2AHEWREUKA42GFEABACC4MVWL2L7FKGE';
+
+    it('updates wallet address with a valid Stellar public key', async () => {
       const user = mockUser();
       userRepo.findOne.mockResolvedValue(user);
-      userRepo.save.mockResolvedValue({ ...user, walletAddress: 'GABC123' });
+      userRepo.save.mockResolvedValue({ ...user, walletAddress: VALID_STELLAR_KEY });
 
-      const result = await service.linkWallet('uuid-1', 'GABC123');
-      expect(result.walletAddress).toBe('GABC123');
+      const result = await service.linkWallet('uuid-1', VALID_STELLAR_KEY);
+      expect(result.walletAddress).toBe(VALID_STELLAR_KEY);
+    });
+
+    it('throws NotFoundException when user does not exist', async () => {
+      userRepo.findOne.mockResolvedValue(null);
+      await expect(
+        service.linkWallet('no-such-id', VALID_STELLAR_KEY),
+      ).rejects.toThrow(NotFoundException);
     });
   });
 

--- a/backend/src/auth/dto/wallet.dto.spec.ts
+++ b/backend/src/auth/dto/wallet.dto.spec.ts
@@ -1,0 +1,38 @@
+import { validate } from 'class-validator';
+import { WalletDto } from './wallet.dto';
+
+// Generated via Keypair.random() from stellar-sdk v12
+const VALID_KEY = 'GB5HA3VWSBWS47VIKMOOMTMA2AHEWREUKA42GFEABACC4MVWL2L7FKGE';
+
+async function validateWallet(address: string) {
+  const dto = new WalletDto();
+  dto.walletAddress = address;
+  return validate(dto);
+}
+
+describe('WalletDto — @IsStellarPublicKey', () => {
+  it('passes for a valid Stellar public key', async () => {
+    const errors = await validateWallet(VALID_KEY);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('fails for a plain string', async () => {
+    const errors = await validateWallet('hello');
+    expect(errors[0].constraints?.isStellarPublicKey).toBeDefined();
+  });
+
+  it('fails for a Stellar secret key (starts with S)', async () => {
+    const errors = await validateWallet('SAYNCJDKOD6DMRXKCLJWO4FVQAWRRABZ5CO7M7EXAEOIHGXPYRKXAQUC');
+    expect(errors[0].constraints?.isStellarPublicKey).toBeDefined();
+  });
+
+  it('fails for an empty string', async () => {
+    const errors = await validateWallet('');
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('fails for a key that is one character short', async () => {
+    const errors = await validateWallet(VALID_KEY.slice(0, 55));
+    expect(errors[0].constraints?.isStellarPublicKey).toBeDefined();
+  });
+});

--- a/backend/src/auth/dto/wallet.dto.ts
+++ b/backend/src/auth/dto/wallet.dto.ts
@@ -1,7 +1,38 @@
-import { IsString, IsNotEmpty } from 'class-validator';
+import { IsString, registerDecorator, ValidationOptions } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { Keypair } from 'stellar-sdk';
+
+export function IsStellarPublicKey(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'isStellarPublicKey',
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: any) {
+          if (typeof value !== 'string') return false;
+          try {
+            Keypair.fromPublicKey(value);
+            return true;
+          } catch {
+            return false;
+          }
+        },
+        defaultMessage() {
+          return 'walletAddress must be a valid Stellar public key (56-character G... address)';
+        },
+      },
+    });
+  };
+}
 
 export class WalletDto {
+  @ApiProperty({
+    description: 'Stellar public key (56-character base32 address starting with G)',
+    example: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+  })
   @IsString()
-  @IsNotEmpty()
+  @IsStellarPublicKey()
   walletAddress: string;
 }

--- a/backend/src/database/migrations/1699900000007-ValidateWalletAddresses.ts
+++ b/backend/src/database/migrations/1699900000007-ValidateWalletAddresses.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ValidateWalletAddresses1699900000007 implements MigrationInterface {
+  name = 'ValidateWalletAddresses1699900000007';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Nullify any existing wallet_address values that are not valid Stellar public keys
+    // Valid Stellar public keys: 56 chars, start with G, base32 alphabet (A-Z, 2-7)
+    await queryRunner.query(`
+      UPDATE "users"
+      SET "wallet_address" = NULL
+      WHERE "wallet_address" IS NOT NULL
+        AND "wallet_address" !~ '^G[A-Z2-7]{55}$'
+    `);
+
+    // Add CHECK constraint to enforce format going forward
+    await queryRunner.query(`
+      ALTER TABLE "users"
+      ADD CONSTRAINT "chk_wallet_address_stellar"
+      CHECK ("wallet_address" IS NULL OR "wallet_address" ~ '^G[A-Z2-7]{55}$')
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "users" DROP CONSTRAINT "chk_wallet_address_stellar"
+    `);
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,6 +1,7 @@
 import 'dotenv/config';
 import { NestFactory } from '@nestjs/core';
-import { ValidationPipe } from '@nestjs/common';
+import { ValidationPipe, BadRequestException } from '@nestjs/common';
+import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
@@ -11,10 +12,28 @@ async function bootstrap() {
       whitelist: true,
       forbidNonWhitelisted: true,
       transform: true,
+      exceptionFactory: (errors) => {
+        const walletError = errors.find((e) => e.property === 'walletAddress' &&
+          e.constraints?.['isStellarPublicKey']);
+        if (walletError) {
+          throw new BadRequestException({
+            code: 'INVALID_WALLET_ADDRESS',
+            message: 'walletAddress must be a valid Stellar public key.',
+          });
+        }
+        throw new BadRequestException(errors);
+      },
     }),
   );
 
   app.enableCors();
+
+  const config = new DocumentBuilder()
+    .setTitle('Agric-onchain Finance API')
+    .setVersion('0.1.0')
+    .addBearerAuth()
+    .build();
+  SwaggerModule.setup('api/docs', app, SwaggerModule.createDocument(app, config));
 
   const port = process.env.PORT ?? 3001;
   await app.listen(port);


### PR DESCRIPTION
- Add @IsStellarPublicKey() custom validator using Keypair.fromPublicKey()
- Return 400 with code INVALID_WALLET_ADDRESS for invalid keys
- Add exceptionFactory to ValidationPipe to shape the error response
- Add migration 1699900000007 to nullify invalid wallet_address rows and add CHECK constraint
- Add wallet.dto.spec.ts with 5 validator unit tests
- Fix auth.service.spec.ts linkWallet test to use a real Stellar public key
- Wire up SwaggerModule at /api/docs and add @ApiProperty to WalletDto