### PR TITLE
feat: add POST /trade-deals/:id/publish endpoint (#56)

### DIFF
--- a/backend/src/queue/queue.service.ts
+++ b/backend/src/queue/queue.service.ts
@@ -19,6 +19,19 @@ export class QueueService {
   }
 
   /**
+   * Enqueue a deal.publish job to issue Trade_Token on Stellar
+   */
+  async enqueueDealPublish(payload: {
+    dealId: string;
+    tokenSymbol: string;
+    escrowPublicKey: string;
+    escrowSecretKey: string;
+    tokenCount: number;
+  }): Promise<void> {
+    await this.emit('deal.publish', payload);
+  }
+
+  /**
    * Enqueue a deal.delivered job to trigger escrow release
    */
   async enqueueDealDelivered(tradeDealId: string): Promise<void> {

--- a/backend/src/trade-deals/trade-deals.controller.ts
+++ b/backend/src/trade-deals/trade-deals.controller.ts
@@ -15,6 +15,8 @@ import { TradeDeal } from './entities/trade-deal.entity';
 import { User } from '../auth/entities/user.entity';
 import { KycGuard } from '../auth/kyc.guard';
 import { CreateTradeDealDto } from './dto/create-trade-deal.dto';
+import { StellarService } from '../stellar/stellar.service';
+import { QueueService } from '../queue/queue.service';
 
 interface AuthRequest extends Request {
   user: User;
@@ -22,7 +24,11 @@ interface AuthRequest extends Request {
 
 @Controller('trade-deals')
 export class TradeDealsController {
-  constructor(private readonly tradeDealsService: TradeDealsService) {}
+  constructor(
+    private readonly tradeDealsService: TradeDealsService,
+    private readonly stellarService: StellarService,
+    private readonly queueService: QueueService,
+  ) {}
 
   @Post()
   @UseGuards(AuthGuard('jwt'), KycGuard)
@@ -38,6 +44,39 @@ export class TradeDealsController {
     }
 
     return this.tradeDealsService.createDeal(req.user.id, dto);
+  }
+
+  @Post(':id/publish')
+  @UseGuards(AuthGuard('jwt'), KycGuard)
+  async publishDeal(
+    @Param('id') id: string,
+    @Request() req: AuthRequest,
+  ): Promise<TradeDeal> {
+    if (req.user.role !== 'trader') {
+      throw new ForbiddenException({
+        code: 'ROLE_REQUIRED',
+        message: 'Only traders can publish trade deals.',
+      });
+    }
+
+    const deal = await this.tradeDealsService.publishDeal(id, req.user.id);
+
+    const { publicKey, secretKey } = await this.stellarService.createEscrowAccount(id);
+
+    await this.tradeDealsService.updateDealStatus(id, 'open');
+    await this.tradeDealsService.saveEscrowKeys(id, publicKey, secretKey);
+
+    await this.queueService.enqueueDealPublish({
+      dealId: id,
+      tokenSymbol: deal.tokenSymbol,
+      escrowPublicKey: publicKey,
+      escrowSecretKey: secretKey,
+      tokenCount: deal.tokenCount,
+    });
+
+    deal.status = 'open';
+    deal.escrowPublicKey = publicKey;
+    return deal;
   }
 
   @Get()

--- a/backend/src/trade-deals/trade-deals.module.ts
+++ b/backend/src/trade-deals/trade-deals.module.ts
@@ -7,6 +7,7 @@ import { Document } from './entities/document.entity';
 import { Investment } from '../investments/entities/investment.entity';
 import { ShipmentMilestone } from '../shipments/entities/shipment-milestone.entity';
 import { User } from '../auth/entities/user.entity';
+import { QueueModule } from '../queue/queue.module';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { User } from '../auth/entities/user.entity';
       ShipmentMilestone,
       User,
     ]),
+    QueueModule,
   ],
   controllers: [TradeDealsController],
   providers: [TradeDealsService],

--- a/backend/src/trade-deals/trade-deals.service.spec.ts
+++ b/backend/src/trade-deals/trade-deals.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import {
   BadRequestException,
+  ForbiddenException,
   NotFoundException,
   UnprocessableEntityException,
 } from '@nestjs/common';
@@ -193,7 +194,7 @@ describe('TradeDealsService', () => {
       ).rejects.toThrow(NotFoundException);
     });
 
-    it('throws BadRequestException when caller is not the assigned trader', async () => {
+    it('throws ForbiddenException when caller is not the assigned trader', async () => {
       tradeDealRepo.findOne.mockResolvedValue({
         ...mockDeal(),
         documents: [{ id: 'doc-1' }],
@@ -201,7 +202,7 @@ describe('TradeDealsService', () => {
 
       await expect(
         service.publishDeal('deal-uuid', 'other-trader-uuid'),
-      ).rejects.toThrow(BadRequestException);
+      ).rejects.toThrow(ForbiddenException);
     });
   });
 

--- a/backend/src/trade-deals/trade-deals.service.ts
+++ b/backend/src/trade-deals/trade-deals.service.ts
@@ -3,6 +3,7 @@ import {
   NotFoundException,
   BadRequestException,
   UnprocessableEntityException,
+  ForbiddenException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -52,6 +53,14 @@ export class TradeDealsService {
       status,
       ...(stellarAssetTxId && { stellarAssetTxId }),
     });
+  }
+
+  async saveEscrowKeys(
+    dealId: string,
+    escrowPublicKey: string,
+    escrowSecretKey: string,
+  ): Promise<void> {
+    await this.tradeDealRepo.update(dealId, { escrowPublicKey, escrowSecretKey });
   }
 
   async createDeal(
@@ -227,7 +236,7 @@ export class TradeDealsService {
     }
 
     if (deal.traderId !== traderId) {
-      throw new BadRequestException({
+      throw new ForbiddenException({
         code: 'NOT_ASSIGNED_TRADER',
         message: 'Only the assigned trader can publish this deal.',
       });


### PR DESCRIPTION
## Summary

Fixes #56 — wires the missing `POST /trade-deals/:id/publish` HTTP route.

## Changes

- **controller**: adds `@Post(':id/publish')` guarded by `AuthGuard('jwt')` + `KycGuard`; enforces `trader` role (403), calls `publishDeal`, creates escrow account on Stellar, persists keys, enqueues `deal.publish`, returns deal with `status: 'open'` and `escrowPublicKey`
- **service**: adds `saveEscrowKeys()`; fixes wrong-trader guard from `BadRequestException` → `ForbiddenException` (403)
- **module**: imports `QueueModule` so `QueueService` is injectable
- **queue.service**: adds `enqueueDealPublish()` emitting `deal.publish` (already consumed by `QueueProcessor`)
- **spec**: updates test expectation to `ForbiddenException` to match corrected behaviour

## Tested

All 68 existing tests pass.