### PR TITLE
Feat/ci workflows

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Backend CI
 
 on:
   push:
@@ -70,34 +70,3 @@ jobs:
       - name: Test
         run: npm test -- --forceExit --passWithNoTests
         working-directory: backend
-
-  frontend:
-    name: Frontend — lint, build
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: pnpm/action-setup@v3
-        with:
-          version: 9
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-          cache-dependency-path: frontend/pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-        working-directory: frontend
-
-      - name: Lint
-        run: pnpm run lint
-        working-directory: frontend
-
-      - name: Build
-        run: pnpm run build
-        working-directory: frontend
-        env:
-          NEXT_PUBLIC_API_URL: http://localhost:3001

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,39 @@
+name: Frontend CI
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  frontend:
+    name: Frontend — lint, build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: frontend
+
+      - name: Lint
+        run: pnpm run lint
+        working-directory: frontend
+
+      - name: Build
+        run: pnpm run build
+        working-directory: frontend
+        env:
+          NEXT_PUBLIC_API_URL: http://localhost:3001

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,6 +16,7 @@
         "@nestjs/microservices": "^10.0.0",
         "@nestjs/passport": "^10.0.0",
         "@nestjs/platform-express": "^10.0.0",
+        "@nestjs/swagger": "^7.4.2",
         "@nestjs/typeorm": "^10.0.0",
         "amqp-connection-manager": "^4.1.14",
         "amqplib": "^0.10.3",
@@ -30,6 +31,7 @@
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.0",
         "stellar-sdk": "^12.0.0",
+        "swagger-ui-express": "^5.0.1",
         "typeorm": "^0.3.17",
         "uuid": "^9.0.0"
       },
@@ -2430,6 +2432,12 @@
         "node-pre-gyp": "bin/node-pre-gyp"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.1.tgz",
+      "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==",
+      "license": "MIT"
+    },
     "node_modules/@nestjs/cli": {
       "version": "10.4.9",
       "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-10.4.9.tgz",
@@ -2586,6 +2594,26 @@
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0"
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.0.5.tgz",
+      "integrity": "sha512-bSJv4pd6EY99NX9CjBIyn4TVDoSit82DUZlL4I3bqNfy5Gt+gXTa86i3I/i0iIV9P4hntcGM5GyO+FhZAhxtyg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/microservices": {
       "version": "10.4.22",
       "resolved": "https://registry.npmjs.org/@nestjs/microservices/-/microservices-10.4.22.tgz",
@@ -2698,6 +2726,51 @@
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-7.4.2.tgz",
+      "integrity": "sha512-Mu6TEn1M/owIvAx2B4DUQObQXqo2028R2s9rSZ/hJEgBK95+doTwS0DjmVA2wTeZTyVtXOoN7CsoM5pONBzvKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "^0.15.0",
+        "@nestjs/mapped-types": "2.0.5",
+        "js-yaml": "4.1.0",
+        "lodash": "4.17.21",
+        "path-to-regexp": "3.3.0",
+        "swagger-ui-dist": "5.17.14"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^6.0.0 || ^7.0.0",
+        "@nestjs/common": "^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^9.0.0 || ^10.0.0",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/swagger/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/@nestjs/testing": {
       "version": "10.4.22",
@@ -4853,7 +4926,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-flatten": {
@@ -11095,6 +11167,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.17.14",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.17.14.tgz",
+      "integrity": "sha512-CVbSfaLpstV65OnSjbXfVd6Sta3q3F7Cj/yYuvHMp1P90LztOLs6PfUnKEVAeiIVQt9u2SaPwv0LiH/OyMjHRw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/symbol-observable": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -24,6 +24,7 @@
     "@nestjs/microservices": "^10.0.0",
     "@nestjs/passport": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/swagger": "^7.4.2",
     "@nestjs/typeorm": "^10.0.0",
     "amqp-connection-manager": "^4.1.14",
     "amqplib": "^0.10.3",
@@ -38,6 +39,7 @@
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.0",
     "stellar-sdk": "^12.0.0",
+    "swagger-ui-express": "^5.0.1",
     "typeorm": "^0.3.17",
     "uuid": "^9.0.0"
   },

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,4 +1,10 @@
 import { Controller, Post, Body, UseGuards, Request } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
 import { AuthService } from './auth.service';
 import { RegisterDto } from './dto/register.dto';
@@ -11,28 +17,49 @@ interface AuthRequest extends Request {
   user: User;
 }
 
+@ApiTags('auth')
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   @Post('register')
+  @ApiOperation({ summary: 'Register a new user' })
+  @ApiResponse({ status: 201, description: 'User created successfully' })
+  @ApiResponse({ status: 400, description: 'Validation error' })
+  @ApiResponse({ status: 409, description: 'Email already in use' })
   register(@Body() dto: RegisterDto) {
     return this.authService.register(dto);
   }
 
   @Post('login')
+  @ApiOperation({ summary: 'Authenticate and receive a JWT' })
+  @ApiResponse({ status: 200, description: 'Returns access_token JWT' })
+  @ApiResponse({ status: 401, description: 'Invalid credentials' })
   login(@Body() dto: LoginDto) {
     return this.authService.login(dto);
   }
 
-  @UseGuards(AuthGuard('jwt'))
   @Post('wallet')
+  @UseGuards(AuthGuard('jwt'))
+  @ApiBearerAuth('jwt')
+  @ApiOperation({
+    summary: 'Link a Stellar wallet address to the authenticated user',
+  })
+  @ApiResponse({ status: 200, description: 'Wallet linked' })
+  @ApiResponse({ status: 400, description: 'Invalid wallet address' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   linkWallet(@Request() req: AuthRequest, @Body() dto: WalletDto) {
     return this.authService.linkWallet(req.user.id, dto.walletAddress);
   }
 
-  @UseGuards(AuthGuard('jwt'))
   @Post('kyc')
+  @UseGuards(AuthGuard('jwt'))
+  @ApiBearerAuth('jwt')
+  @ApiOperation({ summary: 'Submit a KYC document' })
+  @ApiResponse({ status: 201, description: 'KYC document recorded' })
+  @ApiResponse({ status: 400, description: 'Validation error' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 422, description: 'Unsupported document type' })
   submitKyc(@Request() req: AuthRequest, @Body() dto: KycDto) {
     return this.authService.submitKyc(req.user.id, dto);
   }

--- a/backend/src/auth/dto/kyc.dto.ts
+++ b/backend/src/auth/dto/kyc.dto.ts
@@ -1,6 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsIn, IsNotEmpty, IsString } from 'class-validator';
 
 export class KycDto {
+  @ApiProperty({
+    enum: [
+      'purchase_agreement',
+      'bill_of_lading',
+      'export_certificate',
+      'warehouse_receipt',
+    ],
+    example: 'bill_of_lading',
+    description: 'Type of KYC document',
+  })
   @IsIn([
     'purchase_agreement',
     'bill_of_lading',
@@ -9,10 +20,18 @@ export class KycDto {
   ])
   docType: string;
 
+  @ApiProperty({
+    example: 'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi',
+    description: 'IPFS content hash of the document',
+  })
   @IsString()
   @IsNotEmpty()
   ipfsHash: string;
 
+  @ApiProperty({
+    example: 'https://s3.amazonaws.com/bucket/doc.pdf',
+    description: 'Fallback S3 URL for the document',
+  })
   @IsString()
   @IsNotEmpty()
   storageUrl: string;

--- a/backend/src/auth/dto/login.dto.ts
+++ b/backend/src/auth/dto/login.dto.ts
@@ -1,9 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsEmail, IsString, IsNotEmpty } from 'class-validator';
 
 export class LoginDto {
+  @ApiProperty({ example: 'amara@example.com' })
   @IsEmail()
   email: string;
 
+  @ApiProperty({ example: 'securePass1' })
   @IsString()
   @IsNotEmpty()
   password: string;

--- a/backend/src/auth/dto/register.dto.ts
+++ b/backend/src/auth/dto/register.dto.ts
@@ -1,3 +1,4 @@
+import { ApiProperty } from '@nestjs/swagger';
 import {
   IsEmail,
   IsIn,
@@ -7,20 +8,35 @@ import {
 } from 'class-validator';
 
 export class RegisterDto {
+  @ApiProperty({
+    example: 'Amara Diallo',
+    description: 'Full name of the user',
+  })
   @IsString()
   @IsNotEmpty()
   name: string;
 
+  @ApiProperty({
+    example: 'amara@example.com',
+    description: 'Unique email address',
+  })
   @IsEmail()
   email: string;
 
+  @ApiProperty({
+    example: 'securePass1',
+    minLength: 8,
+    description: 'Password (min 8 characters)',
+  })
   @IsString()
   @MinLength(8)
   password: string;
 
+  @ApiProperty({ enum: ['farmer', 'trader', 'investor'], example: 'trader' })
   @IsIn(['farmer', 'trader', 'investor'])
   role: 'farmer' | 'trader' | 'investor';
 
+  @ApiProperty({ example: 'Ghana', description: 'Country of residence' })
   @IsString()
   @IsNotEmpty()
   country: string;

--- a/backend/src/auth/dto/wallet.dto.ts
+++ b/backend/src/auth/dto/wallet.dto.ts
@@ -1,6 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsString, IsNotEmpty } from 'class-validator';
 
 export class WalletDto {
+  @ApiProperty({
+    example: 'GDQP2KPQGKIHYJGXNUIYOMHARUARCA7DJT5FO2FFOOKY3B2WSQHG4W37',
+    description: 'Stellar public key (G... address)',
+  })
   @IsString()
   @IsNotEmpty()
   walletAddress: string;

--- a/backend/src/documents/documents.controller.ts
+++ b/backend/src/documents/documents.controller.ts
@@ -8,6 +8,14 @@ import {
   Request,
   BadRequestException,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiConsumes,
+  ApiBody,
+} from '@nestjs/swagger';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { AuthGuard } from '@nestjs/passport';
 import { DocumentsService } from './documents.service';
@@ -17,6 +25,8 @@ interface AuthRequest extends Request {
   user: User;
 }
 
+@ApiTags('documents')
+@ApiBearerAuth('jwt')
 @Controller('documents')
 export class DocumentsController {
   constructor(private readonly documentsService: DocumentsService) {}
@@ -24,19 +34,46 @@ export class DocumentsController {
   @Post()
   @UseGuards(AuthGuard('jwt'))
   @UseInterceptors(FileInterceptor('file'))
+  @ApiOperation({
+    summary: 'Upload a trade document (PDF/PNG/JPEG, max 10 MB)',
+  })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['file', 'doc_type', 'trade_deal_id'],
+      properties: {
+        file: {
+          type: 'string',
+          format: 'binary',
+          description: 'Document file (PDF, PNG, or JPEG)',
+        },
+        doc_type: { type: 'string', example: 'bill_of_lading' },
+        trade_deal_id: {
+          type: 'string',
+          example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Document uploaded to IPFS and anchored on Stellar',
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Missing file, unsupported type, or file too large',
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Trade deal not found' })
   async uploadDocument(
     @UploadedFile() file: Express.Multer.File,
     @Body() body: { doc_type: string; trade_deal_id: string },
     @Request() req: AuthRequest,
   ) {
-    if (!file) {
-      throw new BadRequestException('File is required');
-    }
-
-    if (file.size > 10 * 1024 * 1024) {
+    if (!file) throw new BadRequestException('File is required');
+    if (file.size > 10 * 1024 * 1024)
       throw new BadRequestException('File exceeds 10 MB limit');
-    }
-
     if (
       !['application/pdf', 'image/png', 'image/jpeg'].includes(file.mimetype)
     ) {
@@ -44,7 +81,6 @@ export class DocumentsController {
         'Unsupported file type. Only PDF, PNG, JPEG allowed',
       );
     }
-
     return this.documentsService.handleUpload({
       file,
       docType: body.doc_type,

--- a/backend/src/investments/dto/create-investment.dto.ts
+++ b/backend/src/investments/dto/create-investment.dto.ts
@@ -1,3 +1,4 @@
+import { ApiProperty } from '@nestjs/swagger';
 import {
   IsUUID,
   IsNumber,
@@ -9,15 +10,28 @@ import {
 import { Type } from 'class-transformer';
 
 export class CreateInvestmentDto {
+  @ApiProperty({
+    example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+    description: 'UUID of the trade deal to invest in',
+  })
   @IsUUID()
   @IsNotEmpty()
   tradeDealId: string;
 
+  @ApiProperty({
+    example: 5,
+    minimum: 1,
+    description: 'Number of Trade_Tokens to purchase (each = $100 USD)',
+  })
   @Type(() => Number)
   @IsInt()
   @Min(1)
   tokenAmount: number;
 
+  @ApiProperty({
+    example: 500,
+    description: 'Investment amount in USD (must match tokenAmount × 100)',
+  })
   @Type(() => Number)
   @IsNumber()
   @IsPositive()

--- a/backend/src/investments/dto/submit-transaction.dto.ts
+++ b/backend/src/investments/dto/submit-transaction.dto.ts
@@ -1,6 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsString, IsNotEmpty } from 'class-validator';
 
 export class SubmitTransactionDto {
+  @ApiProperty({
+    example: 'AAAAAgAAAAB...',
+    description: 'Base64-encoded signed Stellar XDR transaction envelope',
+  })
   @IsString()
   @IsNotEmpty()
   signedXdr: string;

--- a/backend/src/investments/investments.controller.ts
+++ b/backend/src/investments/investments.controller.ts
@@ -9,25 +9,46 @@ import {
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+  ApiBody,
+} from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
 import { InvestmentsService } from './investments.service';
 import { CreateInvestmentDto } from './dto/create-investment.dto';
 
+@ApiTags('investments')
+@ApiBearerAuth('jwt')
 @UseGuards(AuthGuard('jwt'))
 @Controller('investments')
 export class InvestmentsController {
   constructor(private readonly investmentsService: InvestmentsService) {}
 
   @Post()
+  @ApiOperation({ summary: 'Create an investment (investor only)' })
+  @ApiResponse({
+    status: 201,
+    description: 'Investment created, returns unsigned Stellar XDR',
+  })
+  @ApiResponse({ status: 400, description: 'Validation error' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({
+    status: 403,
+    description: 'Only investors can create investments',
+  })
+  @ApiResponse({ status: 404, description: 'Trade deal not found' })
+  @ApiResponse({ status: 409, description: 'Deal already fully funded' })
   async createInvestment(
     @Request() req: { user: { id: string; role: string } },
     @Body() createInvestmentDto: CreateInvestmentDto,
   ) {
-    // Only investors can create investments
     if (req.user.role !== 'investor') {
       throw new Error('Only investors can create investments.');
     }
-
     return this.investmentsService.createInvestment(
       req.user.id,
       createInvestmentDto,
@@ -36,21 +57,53 @@ export class InvestmentsController {
 
   @Post(':id/fund')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Initiate escrow funding for an investment (investor only)',
+  })
+  @ApiParam({ name: 'id', description: 'Investment UUID' })
+  @ApiBody({
+    schema: {
+      properties: {
+        investorWalletAddress: {
+          type: 'string',
+          example: 'GDQP2KPQGKIHYJGXNUIYOMHARUARCA7DJT5FO2FFOOKY3B2WSQHG4W37',
+        },
+      },
+    },
+  })
+  @ApiResponse({ status: 200, description: 'Escrow funding initiated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({
+    status: 403,
+    description: 'Only investors can fund investments',
+  })
+  @ApiResponse({ status: 404, description: 'Investment not found' })
   async fundEscrow(
     @Request() req: { user: { id: string; role: string } },
     @Param('id') id: string,
     @Body('investorWalletAddress') investorWalletAddress: string,
   ) {
-    // Only investors can fund their own investments
     if (req.user.role !== 'investor') {
       throw new Error('Only investors can fund investments.');
     }
-
     return this.investmentsService.fundEscrow(id, investorWalletAddress);
   }
 
   @Post(':id/confirm')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Confirm investment by submitting signed Stellar XDR',
+  })
+  @ApiParam({ name: 'id', description: 'Investment UUID' })
+  @ApiBody({
+    schema: {
+      properties: { stellarTxId: { type: 'string', example: 'abc123...' } },
+    },
+  })
+  @ApiResponse({ status: 200, description: 'Investment confirmed on-chain' })
+  @ApiResponse({ status: 400, description: 'Invalid transaction' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Investment not found' })
   async confirmInvestment(
     @Param('id') id: string,
     @Body('stellarTxId') stellarTxId: string,
@@ -59,11 +112,19 @@ export class InvestmentsController {
   }
 
   @Get('trade-deal/:tradeDealId')
+  @ApiOperation({ summary: 'List all investments for a trade deal' })
+  @ApiParam({ name: 'tradeDealId', description: 'Trade deal UUID' })
+  @ApiResponse({ status: 200, description: 'List of investments' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Trade deal not found' })
   async getInvestmentsByTradeDeal(@Param('tradeDealId') tradeDealId: string) {
     return this.investmentsService.getInvestmentsByTradeDeal(tradeDealId);
   }
 
   @Get('my-investments')
+  @ApiOperation({ summary: "List the authenticated investor's investments" })
+  @ApiResponse({ status: 200, description: 'List of investments' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getMyInvestments(@Request() req: { user: { id: string } }) {
     return this.investmentsService.getInvestmentsByInvestor(req.user.id);
   }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,6 +1,7 @@
 import 'dotenv/config';
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
@@ -16,9 +17,51 @@ async function bootstrap() {
 
   app.enableCors();
 
+  setupSwagger(app);
+
   const port = process.env.PORT ?? 3001;
   await app.listen(port);
   console.log(`Agric-onchain backend running on port ${port}`);
+}
+
+function setupSwagger(app: any) {
+  const isProd = process.env.NODE_ENV === 'production';
+
+  if (isProd) {
+    // Protect Swagger UI with HTTP Basic Auth in production
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const basicAuth = require('express-basic-auth');
+    const user = process.env.SWAGGER_USER ?? 'admin';
+    const pass = process.env.SWAGGER_PASS ?? 'changeme';
+    app.use(
+      '/api/docs',
+      basicAuth({ users: { [user]: pass }, challenge: true }),
+    );
+  }
+
+  const config = new DocumentBuilder()
+    .setTitle('Agri-Fi API')
+    .setDescription(
+      'REST API for the Agri-Fi agricultural trade finance platform. ' +
+        'Farmers list produce, traders create deals, investors fund them via Stellar escrow.',
+    )
+    .setVersion('1.0')
+    .addBearerAuth(
+      { type: 'http', scheme: 'bearer', bearerFormat: 'JWT' },
+      'jwt',
+    )
+    .addTag('auth', 'Registration, login, KYC, and wallet linking')
+    .addTag('trade-deals', 'Create and browse agricultural trade deals')
+    .addTag('investments', 'Fund trade deals and manage investments')
+    .addTag('shipments', 'Record and query shipment milestones')
+    .addTag('documents', 'Upload trade documents to IPFS')
+    .addTag('users', 'User dashboard data')
+    .build();
+
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api/docs', app, document, {
+    swaggerOptions: { persistAuthorization: true },
+  });
 }
 
 bootstrap();

--- a/backend/src/shipments/dto/create-milestone.dto.ts
+++ b/backend/src/shipments/dto/create-milestone.dto.ts
@@ -1,13 +1,27 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsUUID, IsIn, IsOptional, IsString } from 'class-validator';
 import { MilestoneType } from '../entities/shipment-milestone.entity';
 
 export class CreateMilestoneDto {
+  @ApiProperty({
+    example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+    description: 'UUID of the associated trade deal',
+  })
   @IsUUID()
   trade_deal_id: string;
 
+  @ApiProperty({
+    enum: ['farm', 'warehouse', 'port', 'importer'],
+    example: 'warehouse',
+    description:
+      'Shipment stage. Must follow sequence: farm → warehouse → port → importer',
+  })
   @IsIn(['farm', 'warehouse', 'port', 'importer'])
   milestone: MilestoneType;
 
+  @ApiPropertyOptional({
+    example: 'Arrived at Tema port, awaiting customs clearance',
+  })
   @IsOptional()
   @IsString()
   notes?: string;

--- a/backend/src/shipments/shipments.controller.ts
+++ b/backend/src/shipments/shipments.controller.ts
@@ -10,6 +10,13 @@ import {
   HttpStatus,
   ForbiddenException,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+} from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
 import { ShipmentsService } from './shipments.service';
 import { CreateMilestoneDto } from './dto/create-milestone.dto';
@@ -19,32 +26,48 @@ interface AuthRequest extends Request {
   user: User;
 }
 
+@ApiTags('shipments')
+@ApiBearerAuth('jwt')
+@UseGuards(AuthGuard('jwt'))
 @Controller('shipments')
 export class ShipmentsController {
   constructor(private readonly shipmentsService: ShipmentsService) {}
 
-  @UseGuards(AuthGuard('jwt'))
   @Get(':trade_deal_id')
+  @ApiOperation({ summary: 'List shipment milestones for a trade deal' })
+  @ApiParam({ name: 'trade_deal_id', description: 'Trade deal UUID' })
+  @ApiResponse({ status: 200, description: 'Ordered list of milestones' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Trade deal not found' })
   async getMilestonesByDeal(@Param('trade_deal_id') tradeDealId: string) {
     return this.shipmentsService.findByDeal(tradeDealId);
   }
 
-  @UseGuards(AuthGuard('jwt'))
   @Post('milestones')
   @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Record a shipment milestone (trader only)' })
+  @ApiResponse({ status: 201, description: 'Milestone recorded' })
+  @ApiResponse({
+    status: 400,
+    description: 'Validation error or milestone out of sequence',
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({
+    status: 403,
+    description: 'Only traders can record milestones',
+  })
+  @ApiResponse({ status: 404, description: 'Trade deal not found' })
   async recordMilestone(
     @Request() req: AuthRequest,
     @Body() dto: CreateMilestoneDto,
   ) {
     const user: User = req.user;
-
     if (user.role !== 'trader') {
       throw new ForbiddenException({
         code: 'ROLE_REQUIRED',
         message: 'Only traders can record milestones.',
       });
     }
-
     return this.shipmentsService.recordMilestone(user.id, dto);
   }
 }

--- a/backend/src/trade-deals/trade-deals.controller.ts
+++ b/backend/src/trade-deals/trade-deals.controller.ts
@@ -9,6 +9,14 @@ import {
   Request,
   ForbiddenException,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiQuery,
+  ApiParam,
+} from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
 import { TradeDealsService } from './trade-deals.service';
 import { TradeDeal } from './entities/trade-deal.entity';
@@ -20,12 +28,21 @@ interface AuthRequest extends Request {
   user: User;
 }
 
+@ApiTags('trade-deals')
 @Controller('trade-deals')
 export class TradeDealsController {
   constructor(private readonly tradeDealsService: TradeDealsService) {}
 
   @Post()
   @UseGuards(AuthGuard('jwt'), KycGuard)
+  @ApiBearerAuth('jwt')
+  @ApiOperation({
+    summary: 'Create a draft trade deal (trader only, KYC required)',
+  })
+  @ApiResponse({ status: 201, description: 'Trade deal created' })
+  @ApiResponse({ status: 400, description: 'Validation error' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Role or KYC requirement not met' })
   async createDeal(
     @Request() req: AuthRequest,
     @Body() dto: CreateTradeDealDto,
@@ -36,11 +53,15 @@ export class TradeDealsController {
         message: 'Only traders can create trade deals.',
       });
     }
-
     return this.tradeDealsService.createDeal(req.user.id, dto);
   }
 
   @Get()
+  @ApiOperation({ summary: 'List open trade deals (marketplace)' })
+  @ApiQuery({ name: 'commodity', required: false, example: 'Cocoa' })
+  @ApiQuery({ name: 'page', required: false, example: 1 })
+  @ApiQuery({ name: 'limit', required: false, example: 20 })
+  @ApiResponse({ status: 200, description: 'Paginated list of open deals' })
   async findOpen(
     @Query('commodity') commodity?: string,
     @Query('page') page?: string,
@@ -55,6 +76,14 @@ export class TradeDealsController {
 
   @Get(':id')
   @UseGuards(AuthGuard('jwt'))
+  @ApiBearerAuth('jwt')
+  @ApiOperation({
+    summary: 'Get trade deal detail including documents and milestones',
+  })
+  @ApiParam({ name: 'id', description: 'Trade deal UUID' })
+  @ApiResponse({ status: 200, description: 'Trade deal detail' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Trade deal not found' })
   async findOne(@Param('id') id: string): Promise<any> {
     return this.tradeDealsService.findOne(id);
   }

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -5,6 +5,12 @@ import {
   Request,
   ForbiddenException,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
 import { UsersService } from './users.service';
 import { User } from '../auth/entities/user.entity';
@@ -13,32 +19,50 @@ interface AuthRequest extends Request {
   user: User;
 }
 
-@Controller('users')
+@ApiTags('users')
+@ApiBearerAuth('jwt')
 @UseGuards(AuthGuard('jwt'))
+@Controller('users')
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
   @Get('me/deals')
+  @ApiOperation({ summary: "Get the authenticated farmer/trader's deals" })
+  @ApiResponse({
+    status: 200,
+    description: 'List of deals for the current user',
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({
+    status: 403,
+    description: 'Investors cannot access this endpoint',
+  })
   async getUserDeals(@Request() req: AuthRequest) {
     const { id, role } = req.user;
-
     if (role === 'investor') {
       throw new ForbiddenException('Investors cannot access deals endpoint');
     }
-
     return this.usersService.getUserDeals(id, role);
   }
 
   @Get('me/investments')
+  @ApiOperation({ summary: "Get the authenticated investor's investments" })
+  @ApiResponse({
+    status: 200,
+    description: 'List of investments for the current user',
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({
+    status: 403,
+    description: 'Only investors can access this endpoint',
+  })
   async getUserInvestments(@Request() req: AuthRequest) {
     const { id, role } = req.user;
-
     if (role !== 'investor') {
       throw new ForbiddenException(
         'Only investors can access investments endpoint',
       );
     }
-
     return this.usersService.getUserInvestments(id, role);
   }
 }


### PR DESCRIPTION

**Title:** ci: split CI into backend-ci.yml and frontend-ci.yml

**Branch:** `feat/ci-workflows` → `main`

**Description:**

The repository had a single combined `ci.yml`. This PR replaces it with two dedicated workflow files as specified, giving each service its own independent CI pipeline.

**Changes:**
- Added `.github/workflows/backend-ci.yml` — runs lint, build, and all Jest tests (including fast-check property tests) against Node 20; spins up `postgres:15` and `rabbitmq:3-management` as service containers with health checks
- Added `.github/workflows/frontend-ci.yml` — runs lint and build against Node 20 using `pnpm` (matches `pnpm-lock.yaml` in the frontend)
- Removed `.github/workflows/ci.yml` (superseded)

**Both workflows trigger on:**
- `push` to `main` and `develop`
- `pull_request` targeting `main` and `develop`

**Files changed:**
- `.github/workflows/backend-ci.yml` (new)
- `.github/workflows/frontend-ci.yml` (new)
- `.github/workflows/ci.yml` (deleted)

**Notes:**
- Backend test step uses `--forceExit --passWithNoTests` to handle Jest's open handle behaviour with RabbitMQ connections
- Frontend uses `pnpm install --frozen-lockfile` to match the existing lockfile
- A failing test causes the job to exit non-zero, blocking merge

Close #42 