### PR TITLE
fix: align apiClient endpoints with actual backend routes (#60)

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -106,22 +106,29 @@ export const apiClient = {
     return raw ? (JSON.parse(raw) as User) : null;
   },
 
+  // GET /users/me/deals
   async getFarmerDeals(): Promise<Deal[]> {
-    return apiFetch<Deal[]>('/trade-deals/my');
+    return apiFetch<Deal[]>('/users/me/deals');
   },
 
+  // GET /users/me/deals
   async getTraderDeals(): Promise<Deal[]> {
-    return apiFetch<Deal[]>('/trade-deals/my');
+    return apiFetch<Deal[]>('/users/me/deals');
   },
 
+  // GET /investments/my-investments
   async getInvestorInvestments(): Promise<Investment[]> {
-    return apiFetch<Investment[]>('/investments/my');
+    return apiFetch<Investment[]>('/investments/my-investments');
   },
 
-  async recordMilestone(dealId: string, data: { title: string; description: string }) {
-    return apiFetch(`/shipments/${dealId}/milestones`, {
+  // POST /shipments/milestones  — trade_deal_id + milestone + notes in body
+  async recordMilestone(
+    dealId: string,
+    data: { milestone: 'farm' | 'warehouse' | 'port' | 'importer'; notes?: string },
+  ) {
+    return apiFetch('/shipments/milestones', {
       method: 'POST',
-      body: JSON.stringify(data),
+      body: JSON.stringify({ trade_deal_id: dealId, ...data }),
     });
   },
 };


### PR DESCRIPTION
## Problem
Four `apiClient` methods called non-existent backend routes, causing 404s on the farmer, trader, and investor dashboards, and broken milestone recording.

## Changes
| Function | Was | Now |
|---|---|---|
| `getFarmerDeals` | `GET /trade-deals/my` | `GET /users/me/deals` |
| `getTraderDeals` | `GET /trade-deals/my` | `GET /users/me/deals` |
| `getInvestorInvestments` | `GET /investments/my` | `GET /investments/my-investments` |
| `recordMilestone` | `POST /shipments/:id/milestones` | `POST /shipments/milestones` with `trade_deal_id` in body |

`recordMilestone` signature updated from `{title, description}` to `{milestone, notes?}` to match `CreateMilestoneDto`.

Closes #60