### PR TITLE
fix: standardize localStorage key to auth_token and add getStoredToke…

### DIFF
--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useWallet } from '../hooks/useWallet';
+import { getStoredToken } from '../lib/api';
 
 interface InvestmentFormProps {
   dealId: string;
@@ -52,7 +53,7 @@ export const InvestmentForm: React.FC<InvestmentFormProps> = ({
     setSuccess(null);
 
     try {
-      const token = localStorage.getItem('authToken');
+      const token = getStoredToken();
       if (!token) {
         throw new Error('Please log in first');
       }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -62,9 +62,13 @@ export interface Investment {
 
 // ── Auth-aware fetch helper ───────────────────────────────────────────────────
 
+export function getStoredToken(): string | null {
+  if (typeof window === 'undefined') return null;
+  return localStorage.getItem('auth_token');
+}
+
 function authHeaders(): Record<string, string> {
-  if (typeof window === 'undefined') return {};
-  const token = localStorage.getItem('auth_token');
+  const token = getStoredToken();
   return token ? { Authorization: `Bearer ${token}` } : {};
 }
 


### PR DESCRIPTION
pr close #65 

- Export getStoredToken() from lib/api.ts
- Fix InvestmentForm.tsx to use getStoredToken() instead of localStorage.getItem('authToken')