### PR TITLE
fix: replace hardcoded document_count with real GROUP BY query (#59)

### DIFF
--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -5,10 +5,11 @@ import { UsersService } from './users.service';
 import { TradeDeal } from './entities/trade-deal.entity';
 import { Investment } from './entities/investment.entity';
 import { ShipmentMilestone } from '../shipments/entities/shipment-milestone.entity';
+import { Document } from '../trade-deals/entities/document.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([TradeDeal, Investment, ShipmentMilestone]),
+    TypeOrmModule.forFeature([TradeDeal, Investment, ShipmentMilestone, Document]),
   ],
   controllers: [UsersController],
   providers: [UsersService],

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -1,0 +1,139 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ForbiddenException } from '@nestjs/common';
+import { UsersService } from './users.service';
+import { TradeDeal } from './entities/trade-deal.entity';
+import { Investment } from './entities/investment.entity';
+import { ShipmentMilestone } from '../shipments/entities/shipment-milestone.entity';
+import { Document } from '../trade-deals/entities/document.entity';
+
+const mockDeal = (id: string, overrides = {}): TradeDeal =>
+  ({
+    id,
+    commodity: 'cocoa',
+    quantity: 100,
+    totalValue: 10000,
+    totalInvested: 0,
+    status: 'open',
+    deliveryDate: new Date('2026-12-01'),
+    farmerId: 'farmer-1',
+    traderId: 'trader-1',
+    ...overrides,
+  }) as TradeDeal;
+
+describe('UsersService', () => {
+  let service: UsersService;
+
+  const tradeDealRepo = { find: jest.fn() };
+  const investmentRepo = { find: jest.fn() };
+  const milestoneRepo = { findOne: jest.fn() };
+  const documentRepo = { createQueryBuilder: jest.fn() };
+
+  // Helper to mock the GROUP BY query chain
+  const mockDocumentCounts = (rows: { trade_deal_id: string; count: string }[]) => {
+    const qb = {
+      select: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      groupBy: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn().mockResolvedValue(rows),
+    };
+    documentRepo.createQueryBuilder.mockReturnValue(qb);
+    return qb;
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    milestoneRepo.findOne.mockResolvedValue(null);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UsersService,
+        { provide: getRepositoryToken(TradeDeal), useValue: tradeDealRepo },
+        { provide: getRepositoryToken(Investment), useValue: investmentRepo },
+        { provide: getRepositoryToken(ShipmentMilestone), useValue: milestoneRepo },
+        { provide: getRepositoryToken(Document), useValue: documentRepo },
+      ],
+    }).compile();
+
+    service = module.get<UsersService>(UsersService);
+  });
+
+  describe('getUserDeals – document_count', () => {
+    it('returns document_count: 0 when a deal has no documents', async () => {
+      const deal = mockDeal('deal-1');
+      tradeDealRepo.find.mockResolvedValue([deal]);
+      mockDocumentCounts([]); // no rows returned
+
+      const result = await service.getUserDeals('farmer-1', 'farmer');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].document_count).toBe(0);
+    });
+
+    it('returns document_count: 1 when a deal has one document', async () => {
+      const deal = mockDeal('deal-1');
+      tradeDealRepo.find.mockResolvedValue([deal]);
+      mockDocumentCounts([{ trade_deal_id: 'deal-1', count: '1' }]);
+
+      const result = await service.getUserDeals('farmer-1', 'farmer');
+
+      expect(result[0].document_count).toBe(1);
+    });
+
+    it('returns document_count: 5 when a deal has multiple documents', async () => {
+      const deal = mockDeal('deal-1');
+      tradeDealRepo.find.mockResolvedValue([deal]);
+      mockDocumentCounts([{ trade_deal_id: 'deal-1', count: '5' }]);
+
+      const result = await service.getUserDeals('farmer-1', 'farmer');
+
+      expect(result[0].document_count).toBe(5);
+    });
+
+    it('returns correct counts for multiple deals in a single query', async () => {
+      const deal1 = mockDeal('deal-1');
+      const deal2 = mockDeal('deal-2');
+      const deal3 = mockDeal('deal-3');
+      tradeDealRepo.find.mockResolvedValue([deal1, deal2, deal3]);
+      mockDocumentCounts([
+        { trade_deal_id: 'deal-1', count: '0' },
+        { trade_deal_id: 'deal-2', count: '3' },
+        // deal-3 absent from results → should default to 0
+      ]);
+
+      const result = await service.getUserDeals('farmer-1', 'farmer');
+
+      const byId = Object.fromEntries(result.map((r) => [r.id, r]));
+      expect(byId['deal-1'].document_count).toBe(0);
+      expect(byId['deal-2'].document_count).toBe(3);
+      expect(byId['deal-3'].document_count).toBe(0);
+    });
+
+    it('issues exactly one GROUP BY query regardless of deal count', async () => {
+      const deals = ['deal-1', 'deal-2', 'deal-3'].map((id) => mockDeal(id));
+      tradeDealRepo.find.mockResolvedValue(deals);
+      const qb = mockDocumentCounts([]);
+
+      await service.getUserDeals('farmer-1', 'farmer');
+
+      expect(documentRepo.createQueryBuilder).toHaveBeenCalledTimes(1);
+      expect(qb.getRawMany).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns empty array without querying documents when user has no deals', async () => {
+      tradeDealRepo.find.mockResolvedValue([]);
+
+      const result = await service.getUserDeals('farmer-1', 'farmer');
+
+      expect(result).toEqual([]);
+      expect(documentRepo.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenException for investor role', async () => {
+      await expect(service.getUserDeals('investor-1', 'investor')).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+  });
+});

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -5,6 +5,7 @@ import { UserRole } from '../auth/entities/user.entity';
 import { TradeDeal } from './entities/trade-deal.entity';
 import { Investment } from './entities/investment.entity';
 import { ShipmentMilestone } from '../shipments/entities/shipment-milestone.entity';
+import { Document } from '../trade-deals/entities/document.entity';
 
 @Injectable()
 export class UsersService {
@@ -15,6 +16,8 @@ export class UsersService {
     private readonly investmentRepository: Repository<Investment>,
     @InjectRepository(ShipmentMilestone)
     private readonly milestoneRepository: Repository<ShipmentMilestone>,
+    @InjectRepository(Document)
+    private readonly documentRepository: Repository<Document>,
   ) {}
 
   async getUserDeals(userId: string, userRole: UserRole): Promise<any[]> {
@@ -30,7 +33,21 @@ export class UsersService {
       relations: ['farmer', 'trader', 'milestones'],
     });
 
-    // Get document count for each deal (placeholder - would need documents entity)
+    if (deals.length === 0) return [];
+
+    // Single GROUP BY query — no N+1
+    const dealIds = deals.map((d) => d.id);
+    const counts: { trade_deal_id: string; count: string }[] =
+      await this.documentRepository
+        .createQueryBuilder('doc')
+        .select('doc.trade_deal_id', 'trade_deal_id')
+        .addSelect('COUNT(doc.id)', 'count')
+        .where('doc.trade_deal_id IN (:...dealIds)', { dealIds })
+        .groupBy('doc.trade_deal_id')
+        .getRawMany();
+
+    const countMap = new Map(counts.map((r) => [r.trade_deal_id, Number(r.count)]));
+
     const dealsWithCounts = await Promise.all(
       deals.map(async (deal) => {
         const latestMilestone = await this.milestoneRepository.findOne({
@@ -47,7 +64,7 @@ export class UsersService {
           status: deal.status,
           delivery_date: deal.deliveryDate,
           latest_milestone: latestMilestone || null,
-          document_count: 0, // TODO: Implement when documents entity is available
+          document_count: countMap.get(deal.id) ?? 0,
         };
       }),
     );


### PR DESCRIPTION
pr close #59 

- Inject Document repository into UsersService
- Replace document_count: 0 TODO with single GROUP BY count query (no N+1)
- Register Document entity in UsersModule
- Add users.service.spec.ts with 7 unit tests (0, 1, multiple docs)