### PR TITLE
Implement Asset Clawback for Canceled or Fraudulent Deals

### DIFF
--- a/backend/src/stellar/stellar.service.ts
+++ b/backend/src/stellar/stellar.service.ts
@@ -164,10 +164,16 @@ export class StellarService {
           startingBalance: '1.5',
         }),
       )
+      .addOperation(
+        Operation.setOptions({
+          source: issuerKeypair.publicKey(),
+          setFlags: 10, // AuthRevocableFlag (2) | AuthClawbackEnabledFlag (8)
+        }),
+      )
       .setTimeout(30)
       .build();
 
-    fundIssuerTx.sign(this.platformKeypair);
+    fundIssuerTx.sign(this.platformKeypair, issuerKeypair);
     await this.server.submitTransaction(fundIssuerTx);
 
     const tradeAsset = new Asset(assetCode, issuerKeypair.publicKey());
@@ -724,6 +730,51 @@ export class StellarService {
         return 'pending';
       }
       throw err;
+    }
+  }
+
+  /**
+   * Clawbacks tokens from all current holders back to the issuer.
+   */
+  async clawbackTokens(
+    assetCode: string,
+    issuerPublicKey: string,
+    issuerSecret: string,
+    holders: { walletAddress: string; tokenAmount: number }[],
+  ): Promise<void> {
+    const issuerKeypair = Keypair.fromSecret(issuerSecret);
+    const issuerAccount = await this.server.loadAccount(issuerPublicKey);
+    const tradeAsset = new Asset(assetCode, issuerPublicKey);
+
+    const txBuilder = new TransactionBuilder(issuerAccount, {
+      fee: BASE_FEE,
+      networkPassphrase: this.networkPassphrase,
+    });
+
+    for (const holder of holders) {
+      if (holder.tokenAmount > 0) {
+        txBuilder.addOperation(
+          Operation.clawback({
+            asset: tradeAsset,
+            from: holder.walletAddress,
+            amount: holder.tokenAmount.toFixed(7),
+          }),
+        );
+      }
+    }
+
+    const tx = txBuilder.setTimeout(300).build();
+    tx.sign(issuerKeypair);
+
+    try {
+      await this.server.submitTransaction(tx);
+      this.logger.info(
+        { assetCode, issuerPublicKey, holdersCount: holders.length },
+        'Tokens clawed back successfully',
+      );
+    } catch (err: any) {
+      this.logger.error(`Clawback failed: ${err.message}`, err.stack);
+      throw new Error(`Clawback failed: ${err.message}`);
     }
   }
 }

--- a/backend/src/trade-deals/entities/trade-deal.entity.ts
+++ b/backend/src/trade-deals/entities/trade-deal.entity.ts
@@ -71,6 +71,9 @@ export class TradeDeal {
   @Column({ name: 'issuer_public_key', nullable: true })
   issuerPublicKey: string | null;
 
+  @Column({ name: 'issuer_secret_key', nullable: true })
+  issuerSecretKey: string | null;
+
   @Column({
     name: 'total_invested',
     type: 'numeric',

--- a/backend/src/trade-deals/trade-deals.controller.ts
+++ b/backend/src/trade-deals/trade-deals.controller.ts
@@ -105,4 +105,28 @@ export class TradeDealsController {
   async findOne(@Param('id') id: string): Promise<any> {
     return this.tradeDealsService.findOne(id);
   }
+
+  @Post(':id/cancel')
+  @UseGuards(AuthGuard('jwt'), KycGuard)
+  @ApiBearerAuth('jwt')
+  @ApiOperation({
+    summary: 'Cancel a trade deal and trigger clawbacks (trader only, KYC required)',
+  })
+  @ApiResponse({ status: 200, description: 'Trade deal canceled successfully' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Role or KYC requirement not met' })
+  @ApiResponse({ status: 404, description: 'Trade deal not found' })
+  async cancelDeal(
+    @Param('id') id: string,
+    @Request() req: AuthRequest,
+  ): Promise<TradeDeal> {
+    if (req.user.role !== 'trader') {
+      throw new ForbiddenException({
+        code: 'ROLE_REQUIRED',
+        message: 'Only traders can cancel trade deals.',
+      });
+    }
+
+    return this.tradeDealsService.cancelDeal(id, req.user.id);
+  }
 }

--- a/backend/src/trade-deals/trade-deals.service.ts
+++ b/backend/src/trade-deals/trade-deals.service.ts
@@ -106,6 +106,7 @@ export class TradeDealsService {
       escrowPublicKey: null,
       escrowSecretKey: null,
       issuerPublicKey: null,
+      issuerSecretKey: null,
       stellarAssetTxId: null,
     });
 
@@ -270,7 +271,7 @@ export class TradeDealsService {
         { dealId, tokenSymbol: deal.tokenSymbol },
         'Issuing trade token for deal',
       );
-      const { txId: stellarAssetTxId, issuerPublicKey } =
+      const { txId: stellarAssetTxId, issuerPublicKey, issuerSecret } =
         await this.stellarService.issueTradeToken(
           deal.tokenSymbol,
           escrowPublicKey,
@@ -278,12 +279,17 @@ export class TradeDealsService {
           deal.tokenCount,
         );
 
+      // Encrypt the issuer secret
+      const encryptedIssuerSecret =
+        this.stellarService.encryptSecret(issuerSecret);
+
       // Update deal with Stellar data
       await this.tradeDealRepo.update(dealId, {
         status: 'open',
         escrowPublicKey,
         escrowSecretKey: encryptedEscrowSecret,
         issuerPublicKey,
+        issuerSecretKey: encryptedIssuerSecret,
         stellarAssetTxId,
       });
 
@@ -299,6 +305,7 @@ export class TradeDealsService {
         escrowPublicKey,
         escrowSecretKey: encryptedEscrowSecret,
         issuerPublicKey,
+        issuerSecretKey: encryptedIssuerSecret,
         stellarAssetTxId,
       };
     } catch (error) {
@@ -352,6 +359,76 @@ export class TradeDealsService {
     });
 
     return this.documentRepo.save(doc);
+  }
+
+  async cancelDeal(dealId: string, traderId: string): Promise<TradeDeal> {
+    const deal = await this.tradeDealRepo.findOne({
+      where: { id: dealId },
+      relations: ['investments'],
+    });
+
+    if (!deal) {
+      throw new NotFoundException('Trade deal not found.');
+    }
+
+    if (deal.traderId !== traderId) {
+      throw new ForbiddenException({
+        code: 'NOT_ASSIGNED_TRADER',
+        message: 'Only the assigned trader can cancel this deal.',
+      });
+    }
+
+    if (deal.status === 'canceled' as TradeDealStatus) {
+      return deal; // already canceled
+    }
+
+    if (deal.issuerPublicKey && deal.issuerSecretKey && deal.stellarAssetTxId) {
+      // Find all confirmed investments to gather token amounts
+      const confirmedInvestments =
+        deal.investments?.filter((inv) => inv.status === 'confirmed') || [];
+
+      // Create shares array representing wallets holding the tokens
+      const investorShares: { walletAddress: string; tokenAmount: number }[] =
+        confirmedInvestments.map((inv) => ({
+          walletAddress: inv.investorWallet,
+          tokenAmount: Number(inv.tokenAmount),
+        }));
+
+      const tokensSold = investorShares.reduce(
+        (acc, curr) => acc + curr.tokenAmount,
+        0,
+      );
+      const unsoldTokens = Number(deal.tokenCount) - tokensSold;
+
+      // Include escrow account if it holds unsold tokens
+      if (unsoldTokens > 0 && deal.escrowPublicKey) {
+        investorShares.push({
+          walletAddress: deal.escrowPublicKey,
+          tokenAmount: unsoldTokens,
+        });
+      }
+
+      if (investorShares.length > 0) {
+        const issuerSecret = this.stellarService.decryptSecret(
+          deal.issuerSecretKey,
+        );
+
+        this.logger.info(
+          { dealId, tokenCount: deal.tokenCount, holders: investorShares.length },
+          'Initiating clawback for canceled deal',
+        );
+
+        await this.stellarService.clawbackTokens(
+          deal.tokenSymbol,
+          deal.issuerPublicKey,
+          issuerSecret,
+          investorShares,
+        );
+      }
+    }
+
+    deal.status = 'canceled' as TradeDealStatus;
+    return this.tradeDealRepo.save(deal);
   }
 
   private generateTokenSymbol(commodity: string, dealId: string): string {


### PR DESCRIPTION
Close: #84
I have successfully implemented the Asset Clawback feature using Stellar's Protocol 17 feature for canceled trade deals.

Here's a quick summary of the work done:

Enabled Clawback Flag: The issueTradeToken flow in stellar.service.ts was updated to explicitly set the AuthClawbackEnabledFlag (8) along with the AuthRevocableFlag (2) on the issuer account before minting tokens.
Clawback Operation Implementation: I've introduced a clawbackTokens method in stellar.service.ts which securely utilizes Operation.clawback to pull tokens out from an array of respective investor wallets.
Issuer Key Management: Modifying the TradeDeal entity to store an encrypted issuerSecretKey. This allows the platform to authenticate the clawback transaction for canceled deals at a later time. The secret is saved upon triggering publishDeal.
Deal Cancellation Flow: Added the cancelDeal logic in trade-deals.service.ts that triggers the actual token pull back, ensuring tokens return from both investors and the internal escrow account (for unsold tokens).
Controller Setup: The cancelDeal workflow was exposed on a newly protected POST /trade-deals/:id/cancel endpoint within the controller for authorized traders.