### PR TITLE
fix: remove redundant role check in InvestmentsController.createInvestment

### DIFF
--- a/backend/src/investments/investments.controller.spec.ts
+++ b/backend/src/investments/investments.controller.spec.ts
@@ -1,0 +1,61 @@
+import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { RolesGuard } from '../auth/roles.guard';
+import { InvestmentsController } from './investments.controller';
+import { InvestmentsService } from './investments.service';
+import { StellarService } from '../stellar/stellar.service';
+import { CreateInvestmentDto } from './dto/create-investment.dto';
+
+const mockInvestmentsService = {
+  createInvestment: jest.fn(),
+};
+
+const mockStellarService = {} as StellarService;
+
+describe('InvestmentsController', () => {
+  let controller: InvestmentsController;
+  let rolesGuard: RolesGuard;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    controller = new InvestmentsController(
+      mockInvestmentsService as unknown as InvestmentsService,
+      mockStellarService,
+    );
+    rolesGuard = new RolesGuard(new Reflector());
+  });
+
+  it('delegates investment creation to the service for investor role', async () => {
+    const request = { user: { id: 'investor-1', role: 'investor' } };
+    const dto: CreateInvestmentDto = {
+      tradeDealId: '11111111-1111-1111-1111-111111111111',
+      tokenAmount: 5,
+      amountUsd: 500,
+    };
+    const expected = { id: 'investment-1' };
+    mockInvestmentsService.createInvestment.mockResolvedValue(expected);
+
+    const result = await controller.createInvestment(request as any, dto);
+
+    expect(result).toEqual(expected);
+    expect(mockInvestmentsService.createInvestment).toHaveBeenCalledWith(
+      'investor-1',
+      dto,
+    );
+  });
+
+  it('rejects non-investors in RolesGuard before the handler runs', () => {
+    const context = {
+      getHandler: () => InvestmentsController.prototype.createInvestment,
+      getClass: () => InvestmentsController,
+      switchToHttp: () => ({
+        getRequest: () => ({
+          user: { id: 'trader-1', role: 'trader' },
+        }),
+      }),
+    } as unknown as ExecutionContext;
+
+    expect(() => rolesGuard.canActivate(context)).toThrow(ForbiddenException);
+    expect(mockInvestmentsService.createInvestment).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/investments/investments.controller.ts
+++ b/backend/src/investments/investments.controller.ts
@@ -57,9 +57,6 @@ export class InvestmentsController {
     @Request() req: { user: { id: string; role: string } },
     @Body() createInvestmentDto: CreateInvestmentDto,
   ) {
-    if (req.user.role !== 'investor') {
-      throw new Error('Only investors can create investments.');
-    }
     return this.investmentsService.createInvestment(
       req.user.id,
       createInvestmentDto,


### PR DESCRIPTION
Closes #114
Closes #118

## Changes
- Removed the redundant inline role check from InvestmentsController.createInvestment.
- Added investments.controller.spec.ts coverage to verify RolesGuard rejects non-investors before handler/service execution.

## Testing
- Not run locally in this session (per request to proceed without CI).