### PR TITLE
resolve milestones, investment polling, Stellar escrow

### DIFF
--- a/backend/src/shipments/shipments.service.spec.ts
+++ b/backend/src/shipments/shipments.service.spec.ts
@@ -5,6 +5,7 @@ import {
   ForbiddenException,
   UnprocessableEntityException,
 } from '@nestjs/common';
+import { PinoLogger } from 'nestjs-pino';
 import { ShipmentsService } from './shipments.service';
 import {
   ShipmentMilestone,
@@ -78,6 +79,15 @@ describe('ShipmentsService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ShipmentsService,
+        {
+          provide: PinoLogger,
+          useValue: {
+            setContext: jest.fn(),
+            info: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+          },
+        },
         {
           provide: getRepositoryToken(ShipmentMilestone),
           useValue: milestoneRepo,

--- a/backend/src/shipments/shipments.service.ts
+++ b/backend/src/shipments/shipments.service.ts
@@ -3,8 +3,8 @@ import {
   NotFoundException,
   ForbiddenException,
   UnprocessableEntityException,
-  Logger,
 } from '@nestjs/common';
+import { PinoLogger } from 'nestjs-pino';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, DataSource } from 'typeorm';
 import {
@@ -26,9 +26,8 @@ const MILESTONE_SEQUENCE: MilestoneType[] = [
 
 @Injectable()
 export class ShipmentsService {
-  private readonly logger = new Logger(ShipmentsService.name);
-
   constructor(
+    private readonly logger: PinoLogger,
     @InjectRepository(ShipmentMilestone)
     private readonly milestoneRepo: Repository<ShipmentMilestone>,
     @InjectRepository(TradeDeal)
@@ -37,7 +36,9 @@ export class ShipmentsService {
     private readonly queueService: QueueService,
     private readonly config: ConfigService,
     private readonly dataSource: DataSource,
-  ) {}
+  ) {
+    this.logger.setContext(ShipmentsService.name);
+  }
 
   async recordMilestone(
     userId: string,
@@ -131,8 +132,9 @@ export class ShipmentsService {
         // Enqueue deal.delivered job for escrow release
         await this.queueService.enqueueDealDelivered(dto.trade_deal_id);
 
-        this.logger.log(
-          `Deal ${dto.trade_deal_id} transitioned to delivered — escrow release job enqueued`,
+        this.logger.info(
+          { dealId: dto.trade_deal_id },
+          'Deal transitioned to delivered — escrow release job enqueued',
         );
       }
 

--- a/backend/src/stellar/stellar.service.ts
+++ b/backend/src/stellar/stellar.service.ts
@@ -432,9 +432,6 @@ export class StellarService {
     totalValue: number,
   ): Promise<string[]> {
     const escrowKeypair = Keypair.fromSecret(escrowSecret);
-    const escrowAccount = await this.server.loadAccount(
-      escrowKeypair.publicKey(),
-    );
 
     // Convert to stroops (1 XLM = 10^7 stroops)
     const totalStroops = Math.round(totalValue * 1e7);
@@ -457,70 +454,85 @@ export class StellarService {
       throw new Error('Invalid investor token distribution');
     }
 
-    const txBuilder = new TransactionBuilder(escrowAccount, {
-      fee: BASE_FEE,
-      networkPassphrase: this.networkPassphrase,
-    });
-
-    // Farmer payment (USDC)
-    txBuilder.addOperation(
-      Operation.payment({
-        destination: farmerWallet,
-        asset: this.usdcAsset,
-        amount: (farmerStroops / 1e7).toFixed(7),
-      }),
-    );
-
-    // Investors
+    const BATCH_SIZE = 98;
+    const txIds: string[] = [];
     let distributedToInvestors = 0;
+    const batchCount = Math.max(1, Math.ceil(investorShares.length / BATCH_SIZE));
 
-    investorShares.forEach((share, index) => {
-      let shareStroops = Math.floor(
-        (share.tokenAmount / totalTokens) * totalStroops,
+    for (let batchIdx = 0; batchIdx < batchCount; batchIdx++) {
+      const batchStart = batchIdx * BATCH_SIZE;
+      const batch = investorShares.slice(batchStart, batchStart + BATCH_SIZE);
+
+      const batchAccount = await this.server.loadAccount(
+        escrowKeypair.publicKey(),
       );
+      const txBuilder = new TransactionBuilder(batchAccount, {
+        fee: BASE_FEE,
+        networkPassphrase: this.networkPassphrase,
+      });
 
-      // Fix rounding remainder on last investor
-      if (index === investorShares.length - 1) {
-        shareStroops =
-          totalStroops -
-          farmerStroops -
-          platformStroops -
-          distributedToInvestors;
+      if (batchIdx === 0) {
+        txBuilder.addOperation(
+          Operation.payment({
+            destination: farmerWallet,
+            asset: this.usdcAsset,
+            amount: (farmerStroops / 1e7).toFixed(7),
+          }),
+        );
       }
 
-      distributedToInvestors += shareStroops;
+      batch.forEach((share, localIdx) => {
+        const globalIdx = batchStart + localIdx;
+        let shareStroops = Math.floor(
+          (share.tokenAmount / totalTokens) * totalStroops,
+        );
 
-      txBuilder.addOperation(
-        Operation.payment({
-          destination: share.walletAddress,
-          asset: this.usdcAsset,
-          amount: (shareStroops / 1e7).toFixed(7),
-        }),
-      );
-    });
+        if (globalIdx === investorShares.length - 1) {
+          shareStroops =
+            totalStroops -
+            farmerStroops -
+            platformStroops -
+            distributedToInvestors;
+        }
 
-    // Platform fee (USDC)
-    txBuilder.addOperation(
-      Operation.payment({
-        destination: platformWallet,
-        asset: this.usdcAsset,
-        amount: (platformStroops / 1e7).toFixed(7),
-      }),
-    );
+        distributedToInvestors += shareStroops;
 
-    const tx = txBuilder.setTimeout(30).build();
-    tx.sign(escrowKeypair);
+        txBuilder.addOperation(
+          Operation.payment({
+            destination: share.walletAddress,
+            asset: this.usdcAsset,
+            amount: (shareStroops / 1e7).toFixed(7),
+          }),
+        );
+      });
 
-    try {
-      const result = await this.server.submitTransaction(tx);
-      const txId = (result as any).hash as string;
+      if (batchIdx === batchCount - 1) {
+        txBuilder.addOperation(
+          Operation.payment({
+            destination: platformWallet,
+            asset: this.usdcAsset,
+            amount: (platformStroops / 1e7).toFixed(7),
+          }),
+        );
+      }
 
-      this.logger.info({ txId }, 'Escrow released successfully');
-      return [txId];
-    } catch (err: any) {
-      this.logger.error(`Escrow release failed: ${err.message}`, err.stack);
-      throw new Error(`Escrow release failed: ${err.message}`);
+      const tx = txBuilder.setTimeout(30).build();
+      tx.sign(escrowKeypair);
+
+      try {
+        const result = await this.server.submitTransaction(tx);
+        txIds.push((result as any).hash as string);
+      } catch (err: any) {
+        this.logger.error(
+          { batchIdx, totalBatches: batchCount },
+          `Escrow release failed at batch ${batchIdx}: ${err.message}`,
+        );
+        throw new Error(`Escrow release failed: ${err.message}`);
+      }
     }
+
+    this.logger.info({ txIds }, 'Escrow released successfully');
+    return txIds;
   }
 
   /**

--- a/frontend/src/app/api/investments/[id]/route.ts
+++ b/frontend/src/app/api/investments/[id]/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { fetchBackend } from '@/config/backend';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const authHeader = request.headers.get('authorization');
+  try {
+    const response = await fetchBackend(`/investments/${params.id}`, {
+      headers: {
+        Authorization: authHeader ?? '',
+      },
+    });
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } catch (error: any) {
+    if (error?.isBackendUnreachable) {
+      return NextResponse.json(
+        { message: 'Backend service is unavailable' },
+        { status: 503 }
+      );
+    }
+    return NextResponse.json(
+      { message: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/src/app/dashboard/farmer/page.tsx
+++ b/frontend/src/app/dashboard/farmer/page.tsx
@@ -230,22 +230,26 @@ export default function FarmerDashboard() {
                           </div>
 
                           {/* Latest Milestone */}
-                          {latestMilestone && (
-                            <div className="border-t pt-3">
-                              <div className="flex justify-between items-start">
-                                <div className="flex-1">
-                                  <p className="text-sm font-medium text-gray-900">Latest Milestone</p>
-                                  <p className="text-sm text-gray-600">{latestMilestone.title}</p>
-                                  <p className="text-xs text-gray-500 mt-1">
-                                    {formatDate(latestMilestone.created_at)}
-                                  </p>
+                          {latestMilestone && (() => {
+                            const milestoneStatus = latestMilestone.milestone === 'importer' ? 'completed' : 'active';
+                            const milestoneLabel = latestMilestone.milestone.charAt(0).toUpperCase() + latestMilestone.milestone.slice(1);
+                            return (
+                              <div className="border-t pt-3">
+                                <div className="flex justify-between items-start">
+                                  <div className="flex-1">
+                                    <p className="text-sm font-medium text-gray-900">Latest Milestone</p>
+                                    <p className="text-sm text-gray-600">{milestoneLabel}</p>
+                                    <p className="text-xs text-gray-500 mt-1">
+                                      {formatDate(latestMilestone.created_at)}
+                                    </p>
+                                  </div>
+                                  <span className={`px-2 py-1 rounded text-xs font-medium ${getStatusColor(milestoneStatus)}`}>
+                                    {milestoneStatus}
+                                  </span>
                                 </div>
-                                <span className={`px-2 py-1 rounded text-xs font-medium ${getStatusColor(latestMilestone.status)}`}>
-                                  {latestMilestone.status}
-                                </span>
                               </div>
-                            </div>
-                          )}
+                            );
+                          })()}
 
                           {/* Created Date */}
                           <div className="border-t pt-3">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -27,9 +27,7 @@ export interface Document {
 
 export interface Milestone {
   id: string;
-  milestone?: "farm" | "warehouse" | "port" | "importer";
-  title?: string;
-  status?: string;
+  milestone: "farm" | "warehouse" | "port" | "importer";
   notes: string | null;
   recorded_at: string;
   created_at: string;


### PR DESCRIPTION
Summary

Resolves four bugs in the agri-fi platform related to milestones, investment polling, Stellar escrow
batching, and structured logging.

---

### Changes

**Fix: Milestone Interface — remove phantom status and title fields (#206)**

* Removed `status?: string` and `title?: string` from the `Milestone` interface in
  `frontend/src/lib/api.ts` — neither field exists in the `ShipmentMilestone` entity or API response, so both
  were always `undefined`
* Made `milestone` field required (matches entity)
* Updated `FarmerDashboard` (`frontend/src/app/dashboard/farmer/page.tsx`) to derive milestone status from the
  milestone type (`'importer' → 'completed'`, others → `'active'`) and display the milestone type as a
  human-readable label instead of the undefined title

**Fix: Missing GET /api/investments/:id proxy route (#203)**

* Created `frontend/src/app/api/investments/[id]/route.ts` with a GET handler that proxies to the backend
* Returns `503` when the backend is unreachable (consistent with other investment routes)
* Forwards the `Authorization` header for authenticated polling

**Fix: releaseEscrow single-transaction limit (#201)**

* Refactored `StellarService.releaseEscrow` in `backend/src/stellar/stellar.service.ts` to batch investor
  payments into transactions of at most **98 operations**, leaving 2 slots for farmer and platform payments
* Farmer payment is included in the first batch; platform fee in the last batch
* The account is reloaded before each batch to get a fresh sequence number
* All transaction IDs from every batch are collected and returned
* Single-batch behaviour (≤98 investors) is identical to the previous implementation

**Fix: ShipmentsService structured logging (#200)**

* Replaced `new Logger(ShipmentsService.name)` (plain-text `@nestjs/common` logger) with injected
  `PinoLogger` from `nestjs-pino` in `backend/src/shipments/shipments.service.ts`
* Added `this.logger.setContext(ShipmentsService.name)` in the constructor
* Changed `this.logger.log(...)` call to `this.logger.info(...)` with a structured context object
* Updated `backend/src/shipments/shipments.service.spec.ts` to provide a `PinoLogger` mock, matching the pattern
  used in `stellar.service.spec.ts`

---

### Closes

Closes #206
Closes #203
Closes #201
Closes #200
