### PR TITLE
fix/encryption-key-validation

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -19,7 +19,7 @@ STELLAR_PLATFORM_SECRET=your-stellar-secret-key-here # REQUIRED: Platform accoun
 STELLAR_PLATFORM_PUBLIC=your-stellar-public-key-here
 
 # Encryption Configuration
-ENCRYPTION_KEY=your-32-character-encryption-key-here
+ENCRYPTION_KEY=your-32-character-encryption-key-here # Required: 32-byte hex (generate with `openssl rand -hex 32`)
 
 # IPFS/Storage Configuration (Optional)
 IPFS_GATEWAY=https://api.web3.storage

--- a/backend/src/stellar/stellar.service.ts
+++ b/backend/src/stellar/stellar.service.ts
@@ -67,6 +67,15 @@ export class StellarService {
       ? Keypair.fromSecret(platformSecret)
       : Keypair.random();
 
+    // Validate ENCRYPTION_KEY presence (except in test environment)
+    const encryptionKey = config.get<string>('ENCRYPTION_KEY', '');
+    if (!encryptionKey && process.env.NODE_ENV !== 'test') {
+      throw new Error('ENCRYPTION_KEY is required in production and development environments');
+    }
+    if (!encryptionKey && process.env.NODE_ENV === 'test') {
+      this.logger.warn('ENCRYPTION_KEY is not set; using empty key for tests');
+    }
+
     const usdcAssetCode = config.get<string>('USDC_ASSET_CODE', 'USDC');
     const usdcIssuer = config.get<string>('USDC_ISSUER', '');
     this.usdcAsset = usdcIssuer
@@ -386,10 +395,14 @@ export class StellarService {
    */
   encryptSecret(secret: string): string {
     const key = Buffer.from(
-      this.config
-        .get<string>('ENCRYPTION_KEY', '')
-        .padEnd(32, '0')
-        .slice(0, 32),
+      (() => {
+        const rawKey = this.config.get<string>('ENCRYPTION_KEY', '');
+        if (!rawKey) {
+          throw new Error('ENCRYPTION_KEY is not set');
+        }
+        // Expect a 64‑character hex string (32 bytes)
+        return Buffer.from(rawKey, 'hex');
+      })(),
     );
     const iv = randomBytes(16);
     const cipher = createCipheriv('aes-256-cbc', key, iv);
@@ -405,10 +418,13 @@ export class StellarService {
    */
   decryptSecret(encryptedSecret: string): string {
     const key = Buffer.from(
-      this.config
-        .get<string>('ENCRYPTION_KEY', '')
-        .padEnd(32, '0')
-        .slice(0, 32),
+      (() => {
+        const rawKey = this.config.get<string>('ENCRYPTION_KEY', '');
+        if (!rawKey) {
+          throw new Error('ENCRYPTION_KEY is not set');
+        }
+        return Buffer.from(rawKey, 'hex');
+      })(),
     );
     const [ivHex, encryptedHex] = encryptedSecret.split(':');
     const iv = Buffer.from(ivHex, 'hex');


### PR DESCRIPTION
## Description

This PR resolves a critical security vulnerability where the application defaulted to an all-zero AES-256 key when `ENCRYPTION_KEY` was missing. It enforces strict key requirements and replaces unsafe key handling logic with secure parsing.

---

## Key Changes

### Enforced ENCRYPTION_KEY Requirement

- Added validation in `stellar.service.ts` constructor
- Behavior:
  - Throws error in production/development if key is missing
  - Logs warning in test environment to allow test execution
- Ensures application fails fast instead of silently using insecure defaults

---

### Secure Key Handling

- Replaced `padEnd(...).slice(...)` logic with strict hex parsing
- New flow:
  - Retrieve key via `config.get<string>('ENCRYPTION_KEY')`
  - Validate presence
  - Convert directly using `Buffer.from(rawKey, 'hex')`
- Enforces proper 32-byte (64-char hex) AES-256 key usage

---

### Environment Template Update

- Updated `backend/.env.example`
- Marked `ENCRYPTION_KEY` as required
- Added generation guide:
  - `openssl rand -hex 32`

---

## Verification

- Ran full backend test suite (`npm test`) → **Passed**
- Verified encryption/decryption works with valid key
- Confirmed:
  - Warning logged in `NODE_ENV=test` when key is missing
  - Application exits with error when key is missing in non-test environments

---

## Related Issues

Closes #205