### PR TITLE
Moved STELLAR_PLATFORM_WALLET to .env

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -16,6 +16,7 @@ RABBITMQ_URL=amqp://guest:guest@localhost:5672
 STELLAR_NETWORK=testnet
 STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
 STELLAR_PLATFORM_SECRET=your-stellar-secret-key-here # REQUIRED: Platform account keypair secret for signing escrow transactions
+STELLAR_PLATFORM_WALLET=your-stellar-public-key-here
 STELLAR_PLATFORM_PUBLIC=your-stellar-public-key-here
 
 # Encryption Configuration

--- a/backend/src/escrow/escrow.service.ts
+++ b/backend/src/escrow/escrow.service.ts
@@ -9,6 +9,7 @@ import { Investment } from '../investments/entities/investment.entity';
 import { User } from '../auth/entities/user.entity';
 import { StellarService, InvestorShare } from '../stellar/stellar.service';
 import { QueueService } from '../queue/queue.service';
+import { Keypair } from 'stellar-sdk';
 
 interface DealDeliveredPayload {
   tradeDealId: string;
@@ -99,13 +100,22 @@ export class EscrowService {
         }));
 
         // Get platform wallet address
-        const platformWallet = this.config.get<string>(
-          'STELLAR_PLATFORM_WALLET',
-          this.config.get<string>('STELLAR_PLATFORM_SECRET', ''),
-        );
+        let platformWallet = this.config.get<string>('STELLAR_PLATFORM_WALLET');
+        
+        if (!platformWallet) {
+          const platformSecret = this.config.get<string>('STELLAR_PLATFORM_SECRET');
+          if (!platformSecret) {
+             throw new Error('Neither STELLAR_PLATFORM_WALLET nor STELLAR_PLATFORM_SECRET are configured.');
+          }
+          try {
+              platformWallet = Keypair.fromSecret(platformSecret).publicKey();
+          } catch(e) {
+              throw new Error('Invalid STELLAR_PLATFORM_SECRET provided for deriving platform wallet.');
+          }
+        }
 
         if (!platformWallet) {
-          throw new Error('Platform wallet address not configured');
+          throw new Error('Platform wallet address not configured or derivable');
         }
 
         // Release escrow funds via Stellar


### PR DESCRIPTION
Closes #167 

- Utilised `.env` as primary platform wallet
- If not present... new keypair is generated

## Additional Notes
- Add `STELLAR_PLATFORM_WALLET` to `.env`