### PR TITLE
fix: refactor Next.js API routes to use fetchBackend helper (#175)

### DIFF
--- a/frontend/src/app/api/investments/[id]/submit-tx/route.ts
+++ b/frontend/src/app/api/investments/[id]/submit-tx/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { fetchBackend } from '@/config/backend';
 
 export async function POST(
   request: NextRequest,
@@ -8,8 +9,8 @@ export async function POST(
     const body = await request.json();
     const authHeader = request.headers.get('authorization');
 
-    const response = await fetch(
-      `${process.env.BACKEND_URL || 'http://localhost:3001'}/investments/${params.id}/submit-tx`,
+    const response = await fetchBackend(
+      `/investments/${params.id}/submit-tx`,
       {
         method: 'POST',
         headers: {
@@ -27,7 +28,13 @@ export async function POST(
     }
 
     return NextResponse.json(data);
-  } catch (error) {
+  } catch (error: any) {
+    if (error?.isBackendUnreachable) {
+      return NextResponse.json(
+        { message: 'Backend service is unavailable' },
+        { status: 503 }
+      );
+    }
     return NextResponse.json(
       { message: 'Internal server error' },
       { status: 500 }

--- a/frontend/src/app/api/investments/bulk-transaction/route.ts
+++ b/frontend/src/app/api/investments/bulk-transaction/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-
-const BACKEND = process.env.BACKEND_URL ?? 'http://localhost:3001';
+import { fetchBackend } from '@/config/backend';
 
 /**
  * POST /api/investments/bulk-transaction
@@ -12,7 +11,7 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     const authHeader = request.headers.get('authorization');
 
-    const response = await fetch(`${BACKEND}/investments/bulk-transaction`, {
+    const response = await fetchBackend('/investments/bulk-transaction', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -23,7 +22,16 @@ export async function POST(request: NextRequest) {
 
     const data = await response.json();
     return NextResponse.json(data, { status: response.status });
-  } catch {
-    return NextResponse.json({ message: 'Internal server error' }, { status: 500 });
+  } catch (error: any) {
+    if (error?.isBackendUnreachable) {
+      return NextResponse.json(
+        { message: 'Backend service is unavailable' },
+        { status: 503 }
+      );
+    }
+    return NextResponse.json(
+      { message: 'Internal server error' },
+      { status: 500 }
+    );
   }
 }

--- a/frontend/src/app/api/investments/buy-orders/[tokenCode]/[tokenIssuer]/route.ts
+++ b/frontend/src/app/api/investments/buy-orders/[tokenCode]/[tokenIssuer]/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-
-const BACKEND = process.env.BACKEND_URL ?? 'http://localhost:3001';
+import { fetchBackend } from '@/config/backend';
 
 /**
  * GET /api/investments/buy-orders/[tokenCode]/[tokenIssuer]
@@ -15,8 +14,8 @@ export async function GET(
     const authHeader = request.headers.get('authorization');
     const { tokenCode, tokenIssuer } = params;
 
-    const response = await fetch(
-      `${BACKEND}/investments/buy-orders/${encodeURIComponent(tokenCode)}/${encodeURIComponent(tokenIssuer)}`,
+    const response = await fetchBackend(
+      `/investments/buy-orders/${encodeURIComponent(tokenCode)}/${encodeURIComponent(tokenIssuer)}`,
       {
         headers: {
           Authorization: authHeader ?? '',
@@ -26,10 +25,16 @@ export async function GET(
 
     const data = await response.json();
     return NextResponse.json(data, { status: response.status });
-  } catch {
+  } catch (error: any) {
+    if (error?.isBackendUnreachable) {
+      return NextResponse.json(
+        { message: 'Backend service is unavailable' },
+        { status: 503 }
+      );
+    }
     return NextResponse.json(
       { message: 'Internal server error' },
-      { status: 500 },
+      { status: 500 }
     );
   }
 }

--- a/frontend/src/app/api/investments/offers/[tokenCode]/[tokenIssuer]/route.ts
+++ b/frontend/src/app/api/investments/offers/[tokenCode]/[tokenIssuer]/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-
-const BACKEND = process.env.BACKEND_URL ?? 'http://localhost:3001';
+import { fetchBackend } from '@/config/backend';
 
 /**
  * GET /api/investments/offers/[tokenCode]/[tokenIssuer]
@@ -15,8 +14,8 @@ export async function GET(
     const authHeader = request.headers.get('authorization');
     const { tokenCode, tokenIssuer } = params;
 
-    const response = await fetch(
-      `${BACKEND}/investments/offers/${encodeURIComponent(tokenCode)}/${encodeURIComponent(tokenIssuer)}`,
+    const response = await fetchBackend(
+      `/investments/offers/${encodeURIComponent(tokenCode)}/${encodeURIComponent(tokenIssuer)}`,
       {
         headers: {
           Authorization: authHeader ?? '',
@@ -26,7 +25,16 @@ export async function GET(
 
     const data = await response.json();
     return NextResponse.json(data, { status: response.status });
-  } catch {
-    return NextResponse.json({ message: 'Internal server error' }, { status: 500 });
+  } catch (error: any) {
+    if (error?.isBackendUnreachable) {
+      return NextResponse.json(
+        { message: 'Backend service is unavailable' },
+        { status: 503 }
+      );
+    }
+    return NextResponse.json(
+      { message: 'Internal server error' },
+      { status: 500 }
+    );
   }
 }

--- a/frontend/src/app/api/investments/sell-offer/route.ts
+++ b/frontend/src/app/api/investments/sell-offer/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-
-const BACKEND = process.env.BACKEND_URL ?? 'http://localhost:3001';
+import { fetchBackend } from '@/config/backend';
 
 /**
  * POST /api/investments/sell-offer
@@ -12,7 +11,7 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     const authHeader = request.headers.get('authorization');
 
-    const response = await fetch(`${BACKEND}/investments/sell-offer`, {
+    const response = await fetchBackend('/investments/sell-offer', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -23,7 +22,16 @@ export async function POST(request: NextRequest) {
 
     const data = await response.json();
     return NextResponse.json(data, { status: response.status });
-  } catch {
-    return NextResponse.json({ message: 'Internal server error' }, { status: 500 });
+  } catch (error: any) {
+    if (error?.isBackendUnreachable) {
+      return NextResponse.json(
+        { message: 'Backend service is unavailable' },
+        { status: 503 }
+      );
+    }
+    return NextResponse.json(
+      { message: 'Internal server error' },
+      { status: 500 }
+    );
   }
 }

--- a/frontend/src/app/api/stellar/submit/route.ts
+++ b/frontend/src/app/api/stellar/submit/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-
-const BACKEND = process.env.BACKEND_URL ?? 'http://localhost:3001';
+import { fetchBackend } from '@/config/backend';
 
 /**
  * POST /api/stellar/submit
@@ -12,7 +11,7 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     const authHeader = request.headers.get('authorization');
 
-    const response = await fetch(`${BACKEND}/stellar/submit`, {
+    const response = await fetchBackend('/stellar/submit', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -23,7 +22,16 @@ export async function POST(request: NextRequest) {
 
     const data = await response.json();
     return NextResponse.json(data, { status: response.status });
-  } catch {
-    return NextResponse.json({ message: 'Internal server error' }, { status: 500 });
+  } catch (error: any) {
+    if (error?.isBackendUnreachable) {
+      return NextResponse.json(
+        { message: 'Backend service is unavailable' },
+        { status: 503 }
+      );
+    }
+    return NextResponse.json(
+      { message: 'Internal server error' },
+      { status: 500 }
+    );
   }
 }


### PR DESCRIPTION
This PR addresses issue #175 by refactoring several Next.js API proxy routes that were incorrectly using hardcoded process.env.BACKEND_URL instead of the shared fetchBackend helper. This change ensures consistent connection error handling and avoids duplicated fallback logic.

Changes
Refactored Routes: Updated the following proxy routes to use fetchBackend:
/api/investments/bulk-transaction
/api/investments/sell-offer
/api/investments/offers/[tokenCode]/[tokenIssuer]
/api/investments/buy-orders/[tokenCode]/[tokenIssuer]
/api/investments/[id]/submit-tx
/api/stellar/submit
Error Handling: Added checks for isBackendUnreachable in the catch blocks to return a 503 Service Unavailable response instead of a generic 500 error.
Cleaned Up Env Access: Removed all direct references to process.env.BACKEND_URL outside of the centralized config at @/config/backend.
Linked Issues
Closes #175