### PR TITLE
ci: add unresolved merge conflict check to backend and frontend workf…

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -51,6 +51,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Check for unresolved merge conflicts
+        run: |
+          if grep -rn "<<<<<<< " --include="*.ts" --include="*.tsx" --include="*.json" .; then
+            echo "Unresolved merge conflicts found!"
+            exit 1
+          fi
+        working-directory: backend
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -14,6 +14,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Check for unresolved merge conflicts
+        run: |
+          if grep -rn "<<<<<<< " --include="*.ts" --include="*.tsx" --include="*.json" .; then
+            echo "Unresolved merge conflicts found!"
+            exit 1
+          fi
+        working-directory: frontend
+
       - uses: pnpm/action-setup@v3
         with:
           version: 9


### PR DESCRIPTION
Close #188 
`

## PR description

### Summary
Add a safeguard to both backend and frontend CI pipelines that detects unresolved Git merge conflict markers before linting and building.

### What changed
- backend-ci.yml
  - inserted a `Check for unresolved merge conflicts` step after checkout and before setup/install/lint/build
  - searches for `<<<<<<< ` in `*.ts`, `*.tsx`, and `*.json` files
  - exits with failure if any marker is found
- frontend-ci.yml
  - inserted the same conflict-detection step after checkout and before pnpm/setup/lint/build

### Why
This prevents unresolved merge conflict markers from reaching CI later in the pipeline, where they can cause build or compile failures and waste CI cycles.

### Verification
1. Confirm the new workflow step exists in both backend-ci.yml and frontend-ci.yml
2. Run locally in repo root:
   ```bash
   git grep -n '<<<<<<< ' -- '*.ts' '*.tsx' '*.json' || true
   ```
   No output means no unresolved conflict markers are present.
3. Optionally, create a temporary file with `<<<<<<<` and verify the CI step would fail as expected.

### Notes
- No source code changes were required beyond CI workflow updates.
- The task is complete with the new guard now running before lint/build stages in both pipelines.