### PR TITLE
fix(notifications): redact PII and sanitise SMTP credentials in error logs #173`

### DIFF
--- a/backend/src/notifications/notifications.service.spec.ts
+++ b/backend/src/notifications/notifications.service.spec.ts
@@ -66,8 +66,8 @@ describe('NotificationsService', () => {
         html: undefined,
       });
       expect(logger.info).toHaveBeenCalledWith(
-        expect.objectContaining({ to: 'user@test.com' }),
-        expect.any(String),
+        expect.objectContaining({ to: '***@test.com' }),
+        expect.stringContaining('***@test.com'),
       );
     });
 
@@ -79,7 +79,37 @@ describe('NotificationsService', () => {
         service.sendEmail('user@test.com', 'Subject', 'Text'),
       ).rejects.toThrow('SMTP Error');
 
-      expect(logger.error).toHaveBeenCalled();
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: '***@test.com',
+          error: 'SMTP Error',
+        }),
+        expect.stringContaining('***@test.com'),
+      );
+    });
+
+    it('should sanitise SMTP auth details in error logs', async () => {
+      const error = new Error(
+        'Invalid login: 535 5.7.8 Error: authentication failed: AUTH LOGIN abc123def456',
+      );
+      sendMailMock.mockRejectedValue(error);
+
+      await expect(
+        service.sendEmail('user@test.com', 'Subject', 'Text'),
+      ).rejects.toThrow();
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.stringContaining('AUTH ***'),
+        }),
+        expect.any(String),
+      );
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.not.stringContaining('abc123def456'),
+        }),
+        expect.any(String),
+      );
     });
   });
 
@@ -107,7 +137,7 @@ describe('NotificationsService', () => {
       expect(nodemailer.createTransport).not.toHaveBeenCalled();
       expect(sendMailMock).not.toHaveBeenCalled();
       expect(logger.info).toHaveBeenCalledWith(
-        expect.objectContaining({ to: 'user@test.com' }),
+        expect.objectContaining({ to: '***@test.com' }),
         expect.stringContaining('[Test Mode] Simulated sending email'),
       );
     });

--- a/backend/src/notifications/notifications.service.ts
+++ b/backend/src/notifications/notifications.service.ts
@@ -44,7 +44,7 @@ export class NotificationsService {
   ): Promise<void> {
     if (!this.isEnabled || !this.transporter) {
       this.logger.info(
-        { to, subject, text },
+        { to: this.redactEmail(to), subject, text },
         `[Test Mode] Simulated sending email: ${subject}`,
       );
       return;
@@ -62,13 +62,35 @@ export class NotificationsService {
         text,
         html,
       });
-      this.logger.info({ to, subject }, `Successfully sent email to ${to}`);
+      this.logger.info(
+        { to: this.redactEmail(to), subject },
+        `Successfully sent email to ${this.redactEmail(to)}`,
+      );
     } catch (error: any) {
+      const redactedTo = this.redactEmail(to);
+      const sanitisedError = this.sanitiseErrorMessage(error.message);
       this.logger.error(
-        { to, subject, error: error.message },
-        `Failed to send email to ${to}: ${error.message}`,
+        { to: redactedTo, subject, error: sanitisedError },
+        `Failed to send email to ${redactedTo}: ${sanitisedError}`,
       );
       throw error;
     }
+  }
+
+  private redactEmail(email: string): string {
+    if (!email) return '***';
+    const parts = email.split('@');
+    if (parts.length !== 2) return '***';
+    return `***@${parts[1]}`;
+  }
+
+  private sanitiseErrorMessage(message: string): string {
+    if (!message) return '';
+    // Redact SMTP authentication commands and potential tokens
+    return message
+      .replace(/AUTH\s+(?:LOGIN|PLAIN|CRAM-MD5|DIGEST-MD5|XOAUTH2)\s+[a-zA-Z0-9+/=]+/gi, 'AUTH *** [REDACTED]')
+      .replace(/AUTH\s+(?:LOGIN|PLAIN|CRAM-MD5|DIGEST-MD5|XOAUTH2)/gi, 'AUTH ***')
+      // Redact potential base64 credentials (long alphanumeric strings that look like tokens)
+      .replace(/[a-zA-Z0-9+/]{20,}=*/g, '***');
   }
 }


### PR DESCRIPTION
## Overview
This PR addresses security and privacy concerns in the `NotificationsService` by ensuring that sensitive user data (PII) and SMTP authentication credentials are not leaked into application logs.

## Changes
- **PII Redaction**: Implemented `redactEmail` helper to mask the local part of user email addresses in all log outputs (Success, Error, and Test Mode).
    - *Example*: `user@example.com` → `***@example.com`
- **Secret Sanitization**: Added `sanitiseErrorMessage` logic using regular expressions to strip SMTP authentication commands and base64-encoded tokens from error messages before logging.
    - *Example*: `AUTH LOGIN SGVsbG8gd29ybGQ=` → `AUTH *** [REDACTED]`
- **Testing**: Updated `notifications.service.spec.ts` to include assertions for redacted emails and added a new test case specifically for SMTP auth sanitization.
- **Documentation**: Verified that `.env.example` includes the necessary SMTP configuration variables with placeholder values.

## Fixes
- Fixes #173

## Impact
- **Privacy**: Improves GDPR compliance by preventing the storage of user email addresses in log aggregators.
- **Security**: Mitigates the risk of credential leakage in production logs when SMTP authentication fails.

## Verification
- [x] Manual verification of redaction logic via standalone script.
- [x] Unit tests updated and validated to reflect log masking.

---
### Log Examples (Before vs After)

**Before:**
```json
{ "level": "error", "msg": "Failed to send email to user@example.com: Invalid login: 535 AUTH LOGIN SGVsbG8gd29ybGQ=" }
```

**After:**
```json
{ "level": "error", "msg": "Failed to send email to ***@example.com: Invalid login: 535 AUTH *** [REDACTED]" }
```

Closes (#173)