### PR TITLE
fix(security): protect buy-orders endpoint and update OrderBook component

### DIFF
--- a/backend/src/investments/investments.controller.spec.ts
+++ b/backend/src/investments/investments.controller.spec.ts
@@ -91,4 +91,34 @@ describe('InvestmentsController', () => {
       );
     });
   });
+
+  describe('GET /investments/buy-orders/:tokenCode/:tokenIssuer', () => {
+    it('is protected by AuthGuard', () => {
+      const guards =
+        Reflect.getMetadata(
+          '__guards__',
+          InvestmentsController.prototype.getActiveBuyOrders,
+        ) ?? [];
+
+      // The guard list must be non-empty, proving the method has its own
+      // AuthGuard and does not rely solely on the class-level decorator.
+      expect(guards.length).toBeGreaterThan(0);
+    });
+
+    it('delegates to StellarService when the request is authenticated', async () => {
+      const mockOffers = [
+        { offerId: '1', buyer: 'GBUYER...', amount: '100', price: '1.05' },
+      ];
+      (mockStellarService as any).getActiveBuyOrdersForToken = jest
+        .fn()
+        .mockResolvedValue(mockOffers);
+
+      const result = await controller.getActiveBuyOrders('AGRI', 'GISSUER123');
+
+      expect(
+        (mockStellarService as any).getActiveBuyOrdersForToken,
+      ).toHaveBeenCalledWith('AGRI', 'GISSUER123');
+      expect(result).toEqual(mockOffers);
+    });
+  });
 });

--- a/backend/src/investments/investments.controller.ts
+++ b/backend/src/investments/investments.controller.ts
@@ -315,8 +315,14 @@ export class InvestmentsController {
 
   /**
    * Issue #112 — Secondary Market: Fetch active buy orders (bids) for a trade token.
+   *
+   * Security: explicit AuthGuard at the method level ensures this endpoint always
+   * requires a valid JWT, even if the class-level guard is ever refactored away.
+   * Exposing the token issuer public key to unauthenticated callers would allow
+   * anyone to query the Stellar DEX for deal data without authentication.
    */
   @Get('buy-orders/:tokenCode/:tokenIssuer')
+  @UseGuards(AuthGuard('jwt'))
   @ApiOperation({
     summary: 'Get active DEX buy offers for a trade token (buy order book)',
   })
@@ -326,7 +332,10 @@ export class InvestmentsController {
     description: 'Trade token issuer public key',
   })
   @ApiResponse({ status: 200, description: 'List of active buy offers' })
-  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized – valid JWT required to access the order book',
+  })
   async getActiveBuyOrders(
     @Param('tokenCode') tokenCode: string,
     @Param('tokenIssuer') tokenIssuer: string,

--- a/frontend/src/components/OrderBook.tsx
+++ b/frontend/src/components/OrderBook.tsx
@@ -17,26 +17,40 @@ interface OrderBookProps {
 /**
  * Issue #112 — Secondary Market: Active buy offers for a trade token.
  * Displays the DEX buy order book so sellers can see current bids.
+ *
+ * Security: authentication is checked BEFORE the fetch is initiated.
+ * This prevents the token issuer public key from being sent to the backend
+ * without a valid session, keeping the Stellar DEX querying surface private.
  */
 export const OrderBook: React.FC<OrderBookProps> = ({
   tradeTokenCode,
   tradeTokenIssuer,
 }) => {
   const [offers, setOffers] = useState<Offer[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean | null>(null);
 
   useEffect(() => {
-    if (!tradeTokenCode || !tradeTokenIssuer) return;
-
+    // Resolve auth state client-side (localStorage is not available during SSR).
     const token =
       typeof window !== 'undefined' ? localStorage.getItem('auth_token') : null;
+
+    setIsAuthenticated(!!token);
+
+    // Do NOT proceed with the fetch when there is no valid session.
+    // This ensures the token issuer public key is never included in an
+    // unauthenticated request to the backend.
+    if (!token) return;
+    if (!tradeTokenCode || !tradeTokenIssuer) return;
+
+    setIsLoading(true);
 
     fetch(
       `/api/investments/buy-orders/${encodeURIComponent(tradeTokenCode)}/${encodeURIComponent(tradeTokenIssuer)}`,
       {
         headers: {
-          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          Authorization: `Bearer ${token}`,
         },
       },
     )
@@ -45,31 +59,86 @@ export const OrderBook: React.FC<OrderBookProps> = ({
         return res.json() as Promise<Offer[]>;
       })
       .then(setOffers)
-      .catch((err) => setError(err.message ?? 'Could not load order book'))
+      .catch((err: unknown) => {
+        const message =
+          err instanceof Error ? err.message : 'Could not load order book';
+        setError(message);
+      })
       .finally(() => setIsLoading(false));
   }, [tradeTokenCode, tradeTokenIssuer]);
 
   const truncate = (addr: string) => `${addr.slice(0, 6)}…${addr.slice(-4)}`;
 
+  // ── Unauthenticated state ─────────────────────────────────────────────────
+  if (isAuthenticated === false) {
+    return (
+      <section
+        className="bg-white rounded-2xl shadow-sm border border-green-100 p-6"
+        data-testid="order-book-login-prompt"
+      >
+        <h2 className="text-lg font-semibold text-gray-800 mb-1">
+          Secondary Market — Active Buy Orders
+        </h2>
+        <p className="text-xs text-gray-400 mb-6">
+          Stellar DEX bids for{' '}
+          <span className="font-mono">{tradeTokenCode}</span>
+        </p>
+
+        <div className="flex flex-col items-center justify-center py-8 gap-3 text-center">
+          {/* Lock icon */}
+          <svg
+            className="w-10 h-10 text-green-300"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={1.5}
+              d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
+            />
+          </svg>
+
+          <p className="text-sm font-medium text-gray-700">
+            Connect wallet to view order book
+          </p>
+          <p className="text-xs text-gray-400 max-w-xs">
+            You must be signed in to access the secondary market order book.
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  // ── Authenticated state ───────────────────────────────────────────────────
   return (
-    <section className="bg-white rounded-2xl shadow-sm border border-green-100 p-6">
+    <section
+      className="bg-white rounded-2xl shadow-sm border border-green-100 p-6"
+      data-testid="order-book"
+    >
       <h2 className="text-lg font-semibold text-gray-800 mb-1">
         Secondary Market — Active Buy Orders
       </h2>
       <p className="text-xs text-gray-400 mb-4">
-        Stellar DEX bids for <span className="font-mono">{tradeTokenCode}</span>
+        Stellar DEX bids for{' '}
+        <span className="font-mono">{tradeTokenCode}</span>
       </p>
 
+      {/* Loading indicator shown only while the authenticated fetch is in flight */}
       {isLoading && (
-        <p className="text-sm text-gray-400 animate-pulse">Loading order book…</p>
+        <p className="text-sm text-gray-400 animate-pulse">
+          Loading order book…
+        </p>
       )}
 
-      {error && (
-        <p className="text-sm text-red-500">{error}</p>
-      )}
+      {error && <p className="text-sm text-red-500">{error}</p>}
 
       {!isLoading && !error && offers.length === 0 && (
-        <p className="text-sm text-gray-400">No active buy orders for this token.</p>
+        <p className="text-sm text-gray-400">
+          No active buy orders for this token.
+        </p>
       )}
 
       {offers.length > 0 && (

--- a/frontend/src/components/__tests__/OrderBook.test.tsx
+++ b/frontend/src/components/__tests__/OrderBook.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * Issue #112 security fix — OrderBook component tests.
+ *
+ * Verifies that:
+ *  1. An unauthenticated user sees the "Connect wallet" prompt and
+ *     the buy-orders fetch is NEVER initiated.
+ *  2. An authenticated user triggers the fetch and sees the order table.
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { OrderBook } from '../OrderBook';
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+/** Seed localStorage with a fake JWT so the component treats the user as logged in. */
+const setAuthToken = (token: string | null) => {
+  if (token) {
+    localStorage.setItem('auth_token', token);
+  } else {
+    localStorage.removeItem('auth_token');
+  }
+};
+
+const TOKEN_CODE = 'AGRI';
+const TOKEN_ISSUER = 'GISSUER1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+// ── setup / teardown ───────────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  localStorage.clear();
+  // Reset global fetch mock
+  global.fetch = jest.fn();
+});
+
+// ── tests ──────────────────────────────────────────────────────────────────
+
+describe('OrderBook – unauthenticated user', () => {
+  it('shows the login prompt and does NOT call fetch', () => {
+    setAuthToken(null); // no token in localStorage
+
+    render(
+      <OrderBook tradeTokenCode={TOKEN_CODE} tradeTokenIssuer={TOKEN_ISSUER} />,
+    );
+
+    // Login prompt must be visible
+    expect(
+      screen.getByText('Connect wallet to view order book'),
+    ).toBeInTheDocument();
+
+    // The buy-orders URL must never be requested
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('does NOT render the order-book table when unauthenticated', () => {
+    setAuthToken(null);
+
+    render(
+      <OrderBook tradeTokenCode={TOKEN_CODE} tradeTokenIssuer={TOKEN_ISSUER} />,
+    );
+
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+  });
+
+  it('does NOT include the token issuer in any network request', () => {
+    setAuthToken(null);
+
+    render(
+      <OrderBook tradeTokenCode={TOKEN_CODE} tradeTokenIssuer={TOKEN_ISSUER} />,
+    );
+
+    // fetch should not have been called at all, so the issuer was never sent
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('OrderBook – authenticated user', () => {
+  const FAKE_TOKEN = 'eyJhbGciOiJIUzI1NiJ9.test.sig';
+
+  const MOCK_OFFERS = [
+    { offerId: '1', buyer: 'GBUYERAAAA', amount: '50', price: '1.10' },
+    { offerId: '2', buyer: 'GBUYERBBBB', amount: '25', price: '1.05' },
+  ];
+
+  beforeEach(() => {
+    setAuthToken(FAKE_TOKEN);
+
+    // Successful fetch returning two offers
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => MOCK_OFFERS,
+    });
+  });
+
+  it('calls the buy-orders endpoint with an Authorization header', async () => {
+    render(
+      <OrderBook tradeTokenCode={TOKEN_CODE} tradeTokenIssuer={TOKEN_ISSUER} />,
+    );
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+
+    const [url, options] = (global.fetch as jest.Mock).mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+
+    expect(url).toContain('/api/investments/buy-orders/');
+    expect((options.headers as Record<string, string>)['Authorization']).toBe(
+      `Bearer ${FAKE_TOKEN}`,
+    );
+  });
+
+  it('renders fetched offers in the table', async () => {
+    render(
+      <OrderBook tradeTokenCode={TOKEN_CODE} tradeTokenIssuer={TOKEN_ISSUER} />,
+    );
+
+    await waitFor(() => expect(screen.getByRole('table')).toBeInTheDocument());
+
+    // Both offers should appear as rows
+    expect(screen.getByText('50')).toBeInTheDocument();
+    expect(screen.getByText('25')).toBeInTheDocument();
+  });
+
+  it('shows an error message when the API returns a non-OK response', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      json: async () => ({}),
+    });
+
+    render(
+      <OrderBook tradeTokenCode={TOKEN_CODE} tradeTokenIssuer={TOKEN_ISSUER} />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText('Failed to load offers')).toBeInTheDocument(),
+    );
+
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #176

---

Closes #174

---

This PR patches a security vulnerability by requiring authentication for the `buy-orders` endpoint.

- **Backend**: Checks authentication on `buy-orders/:tokenCode/:tokenIssuer` and returns 401 if unauthorized. Does not expose the token issuer public key to unauthenticated users.
- **Frontend**: `OrderBook` component now checks for user authentication before fetching the order book and displays a "Connect wallet" prompt if unauthenticated.