### PR TITLE
Fix branding tokens and add reusable currency input

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -10,25 +10,42 @@
     --font-inter: 'Inter', system-ui, sans-serif;
     --radius: 0.75rem;
     --sidebar-w: 15rem;
+    --color-primary: 142 50% 24%;
+    --color-primary-foreground: 42 33% 98%;
+    --color-primary-muted: 142 36% 92%;
+    --color-secondary: 38 88% 40%;
+    --color-secondary-foreground: 28 72% 14%;
+    --color-secondary-muted: 40 90% 92%;
+    --color-neutral: 28 10% 35%;
+    --color-neutral-foreground: 42 33% 98%;
+    --color-neutral-muted: 36 18% 92%;
+    --color-canvas: 42 33% 98%;
+    --color-surface: 0 0% 100%;
+    --color-border: 32 18% 84%;
+    --color-text: 148 20% 15%;
+    --color-muted-text: 28 8% 36%;
   }
 
   html { scroll-behavior: smooth; -webkit-font-smoothing: antialiased; }
 
   body {
     font-family: var(--font-inter);
-    @apply text-slate-900 bg-slate-50;
+    @apply text-foreground bg-canvas;
     font-feature-settings: 'cv02','cv03','cv04','cv11';
   }
 
   * { box-sizing: border-box; }
 
-  ::selection { @apply bg-brand-100 text-brand-900; }
+  ::selection {
+    background-color: hsl(var(--color-secondary) / 0.24);
+    color: hsl(var(--color-text));
+  }
 
   /* Scrollbar */
   ::-webkit-scrollbar       { width: 6px; height: 6px; }
   ::-webkit-scrollbar-track { @apply bg-transparent; }
-  ::-webkit-scrollbar-thumb { @apply bg-slate-200 rounded-full; }
-  ::-webkit-scrollbar-thumb:hover { @apply bg-slate-300; }
+  ::-webkit-scrollbar-thumb { @apply bg-neutral/20 rounded-full; }
+  ::-webkit-scrollbar-thumb:hover { @apply bg-neutral/35; }
 }
 
 @layer components {
@@ -45,36 +62,36 @@
   .btn-lg  { @apply btn px-7 py-3.5 text-base; }
 
   .btn-primary {
-    @apply btn-md bg-brand-600 text-white hover:bg-brand-700
-           shadow-sm hover:shadow-md focus-visible:ring-brand-500;
+    @apply btn-md bg-primary text-primary-foreground hover:bg-primary/90
+           shadow-sm hover:shadow-md focus-visible:ring-primary/35;
   }
   .btn-secondary {
-    @apply btn-md bg-white text-slate-700 border border-slate-200
-           hover:bg-slate-50 hover:border-slate-300 shadow-sm
-           focus-visible:ring-slate-400;
+    @apply btn-md bg-surface text-foreground border border-border
+           hover:bg-secondary-muted hover:border-secondary/30 shadow-sm
+           focus-visible:ring-secondary/35;
   }
   .btn-ghost {
-    @apply btn-md text-slate-600 hover:bg-slate-100 hover:text-slate-900
-           focus-visible:ring-slate-400;
+    @apply btn-md text-muted-foreground hover:bg-neutral-muted hover:text-foreground
+           focus-visible:ring-neutral/30;
   }
   .btn-danger {
     @apply btn-md bg-red-600 text-white hover:bg-red-700
            shadow-sm focus-visible:ring-red-500;
   }
   .btn-outline-primary {
-    @apply btn-md border-2 border-brand-600 text-brand-700
-           hover:bg-brand-50 focus-visible:ring-brand-500;
+    @apply btn-md border-2 border-primary text-primary
+           hover:bg-primary-muted focus-visible:ring-primary/35;
   }
 
   /* ── Cards ────────────────────────────────────────────────────────────── */
   .card {
-    @apply bg-white rounded-2xl border border-slate-100 shadow-card;
+    @apply bg-surface rounded-2xl border border-border shadow-card;
   }
   .card-hover {
     @apply card hover:shadow-card-md hover:-translate-y-0.5 transition-all duration-200;
   }
   .card-interactive {
-    @apply card cursor-pointer hover:shadow-card-md hover:border-brand-200
+    @apply card cursor-pointer hover:shadow-card-md hover:border-primary/20
            hover:-translate-y-0.5 transition-all duration-200;
   }
   .stat-card {
@@ -83,19 +100,19 @@
 
   /* ── Form elements ────────────────────────────────────────────────────── */
   .input {
-    @apply w-full bg-white border border-slate-200 rounded-xl px-4 py-2.5 text-sm
-           text-slate-900 placeholder:text-slate-400
-           focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-brand-500
+    @apply w-full bg-surface border border-border rounded-xl px-4 py-2.5 text-sm
+           text-foreground placeholder:text-muted-foreground/70
+           focus:outline-none focus:ring-2 focus:ring-primary/35 focus:border-primary
            transition-all duration-150;
   }
   .input-error {
     @apply input border-red-300 focus:ring-red-400 focus:border-red-400;
   }
   .label {
-    @apply block text-sm font-medium text-slate-700 mb-1.5;
+    @apply block text-sm font-medium text-foreground mb-1.5;
   }
   .label-hint {
-    @apply text-xs text-slate-400 mt-1;
+    @apply text-xs text-muted-foreground mt-1;
   }
   .select {
     @apply input appearance-none cursor-pointer;
@@ -122,17 +139,17 @@
 
   /* ── Typography ───────────────────────────────────────────────────────── */
   .page-title   { @apply text-2xl font-bold text-slate-900 tracking-tight; }
-  .section-title{ @apply text-lg font-semibold text-slate-900; }
-  .muted        { @apply text-sm text-slate-500; }
+  .section-title{ @apply text-lg font-semibold text-foreground; }
+  .muted        { @apply text-sm text-muted-foreground; }
 
   /* ── Layout helpers ───────────────────────────────────────────────────── */
   .page-content { @apply p-6 max-w-7xl mx-auto space-y-6; }
-  .divider      { @apply border-t border-slate-100; }
+  .divider      { @apply border-t border-border; }
 
   /* ── Progress bar ─────────────────────────────────────────────────────── */
   .progress-track { @apply h-2 bg-slate-100 rounded-full overflow-hidden; }
   .progress-fill  { @apply h-full rounded-full transition-all duration-700 ease-out; }
-  .progress-green { @apply progress-fill bg-gradient-to-r from-brand-400 to-emerald-500; }
+  .progress-green { @apply progress-fill bg-gradient-to-r from-primary to-secondary; }
   .progress-blue  { @apply progress-fill bg-gradient-to-r from-blue-400 to-indigo-500; }
   .progress-purple{ @apply progress-fill bg-gradient-to-r from-violet-400 to-purple-500; }
 
@@ -164,19 +181,19 @@
 
   /* ── Table ────────────────────────────────────────────────────────────── */
   .table-wrapper { @apply card overflow-hidden; }
-  .table-head    { @apply bg-slate-50 border-b border-slate-100; }
-  .table-th      { @apply px-4 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wider; }
-  .table-td      { @apply px-4 py-3.5 text-sm text-slate-700; }
-  .table-row     { @apply border-b border-slate-50 hover:bg-slate-50/60 transition-colors; }
+  .table-head    { @apply bg-neutral-muted border-b border-border; }
+  .table-th      { @apply px-4 py-3 text-left text-xs font-semibold text-muted-foreground uppercase tracking-wider; }
+  .table-td      { @apply px-4 py-3.5 text-sm text-foreground; }
+  .table-row     { @apply border-b border-border/50 hover:bg-neutral-muted/50 transition-colors; }
 
   /* ── Nav link ─────────────────────────────────────────────────────────── */
   .nav-link {
     @apply flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium
-           text-slate-500 hover:bg-slate-100 hover:text-slate-900
+           text-muted-foreground hover:bg-neutral-muted hover:text-foreground
            transition-all duration-150;
   }
   .nav-link-active {
-    @apply nav-link bg-brand-600 text-white hover:bg-brand-700 hover:text-white
+    @apply nav-link bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground
            shadow-sm;
   }
 }
@@ -187,7 +204,12 @@
 
 /* ── Gradient text ──────────────────────────────────────────────────────────── */
 .gradient-text {
-  background: linear-gradient(135deg, #16a34a 0%, #059669 50%, #0d9488 100%);
+  background: linear-gradient(
+    135deg,
+    hsl(var(--color-primary)) 0%,
+    hsl(var(--color-secondary)) 55%,
+    hsl(var(--color-neutral)) 100%
+  );
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;

--- a/frontend/src/components/__tests__/CurrencyInput.test.tsx
+++ b/frontend/src/components/__tests__/CurrencyInput.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CurrencyInput } from '../ui/CurrencyInput';
+
+describe('CurrencyInput', () => {
+  it('formats USD values with commas and two decimals on blur', async () => {
+    const user = userEvent.setup();
+    let value = '1234.5';
+    const handleChange = jest.fn((nextValue: string) => {
+      value = nextValue;
+      rerenderInput();
+    });
+
+    const rerenderInput = () =>
+      view.rerender(
+        <CurrencyInput
+          aria-label="USD amount"
+          currency="usd"
+          prefix="$"
+          value={value}
+          onChange={handleChange}
+        />,
+      );
+
+    const view = render(
+      <CurrencyInput
+        aria-label="USD amount"
+        currency="usd"
+        prefix="$"
+        value={value}
+        onChange={handleChange}
+      />,
+    );
+
+    const input = screen.getByLabelText('USD amount');
+    expect(input).toHaveValue('1,234.5');
+
+    await user.click(input);
+    await user.tab();
+
+    expect(handleChange).toHaveBeenLastCalledWith('1234.50');
+    expect(screen.getByLabelText('USD amount')).toHaveValue('1,234.50');
+  });
+
+  it('restricts USD input to positive decimals with two places', async () => {
+    const user = userEvent.setup();
+    let value = '';
+    const handleChange = jest.fn((nextValue: string) => {
+      value = nextValue;
+      rerenderInput();
+    });
+
+    const rerenderInput = () =>
+      view.rerender(
+        <CurrencyInput
+          aria-label="USD amount"
+          currency="usd"
+          value={value}
+          onChange={handleChange}
+        />,
+      );
+
+    const view = render(
+      <CurrencyInput
+        aria-label="USD amount"
+        currency="usd"
+        value={value}
+        onChange={handleChange}
+      />,
+    );
+
+    const input = screen.getByLabelText('USD amount');
+    await user.type(input, 'abc1234.567');
+
+    expect(handleChange).toHaveBeenLastCalledWith('1234.56');
+    expect(screen.getByLabelText('USD amount')).toHaveValue('1,234.56');
+  });
+
+  it('supports Stellar precision with seven decimals and suffixes', async () => {
+    const user = userEvent.setup();
+    let value = '';
+    const handleChange = jest.fn((nextValue: string) => {
+      value = nextValue;
+      rerenderInput();
+    });
+
+    const rerenderInput = () =>
+      view.rerender(
+        <CurrencyInput
+          aria-label="XLM amount"
+          currency="stellar"
+          suffix="XLM"
+          value={value}
+          onChange={handleChange}
+        />,
+      );
+
+    const view = render(
+      <CurrencyInput
+        aria-label="XLM amount"
+        currency="stellar"
+        suffix="XLM"
+        value={value}
+        onChange={handleChange}
+      />,
+    );
+
+    const input = screen.getByLabelText('XLM amount');
+    await user.type(input, '10.123456789');
+    await user.tab();
+
+    expect(handleChange).toHaveBeenLastCalledWith('10.1234567');
+    expect(screen.getByLabelText('XLM amount')).toHaveValue('10.1234567');
+    expect(screen.getByText('XLM')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ui/CurrencyInput.tsx
+++ b/frontend/src/components/ui/CurrencyInput.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+
+type CurrencyKind = 'usd' | 'stellar';
+
+export interface CurrencyInputProps
+  extends Omit<
+    React.InputHTMLAttributes<HTMLInputElement>,
+    'type' | 'value' | 'onChange'
+  > {
+  value: string;
+  onChange: (value: string) => void;
+  currency?: CurrencyKind;
+  prefix?: string;
+  suffix?: string;
+}
+
+const DECIMAL_PLACES: Record<CurrencyKind, number> = {
+  usd: 2,
+  stellar: 7,
+};
+
+function getDecimalPlaces(currency: CurrencyKind): number {
+  return DECIMAL_PLACES[currency];
+}
+
+function sanitizeValue(value: string, decimalPlaces: number): string {
+  const cleaned = value.replace(/[^0-9.]/g, '');
+  if (!cleaned) {
+    return '';
+  }
+
+  const [rawInteger, ...rawDecimals] = cleaned.split('.');
+  const integerPart = rawInteger.replace(/^0+(?=\d)/, '') || '0';
+  const decimalPart = rawDecimals.join('').slice(0, decimalPlaces);
+
+  return cleaned.includes('.')
+    ? `${integerPart}.${decimalPart}`
+    : integerPart;
+}
+
+function formatForDisplay(value: string): string {
+  if (!value) {
+    return '';
+  }
+
+  const [integerPart, decimalPart] = value.split('.');
+  const formattedInteger = Number(integerPart || '0').toLocaleString('en-US');
+
+  if (value.endsWith('.') && decimalPart === undefined) {
+    return `${formattedInteger}.`;
+  }
+
+  return decimalPart !== undefined
+    ? `${formattedInteger}.${decimalPart}`
+    : formattedInteger;
+}
+
+function normalizeOnBlur(value: string, decimalPlaces: number): string {
+  if (!value) {
+    return '';
+  }
+
+  const numericValue = Number(value);
+  if (Number.isNaN(numericValue)) {
+    return '';
+  }
+
+  return numericValue.toFixed(decimalPlaces);
+}
+
+export const CurrencyInput: React.FC<CurrencyInputProps> = ({
+  value,
+  onChange,
+  currency = 'usd',
+  prefix,
+  suffix,
+  className = '',
+  onBlur,
+  ...props
+}) => {
+  const decimalPlaces = getDecimalPlaces(currency);
+
+  return (
+    <div className="relative flex items-center">
+      {prefix ? (
+        <span className="pointer-events-none absolute left-4 text-sm font-medium text-neutral">
+          {prefix}
+        </span>
+      ) : null}
+      <input
+        {...props}
+        type="text"
+        inputMode="decimal"
+        value={formatForDisplay(value)}
+        onChange={(event) => {
+          const nextValue = sanitizeValue(event.target.value, decimalPlaces);
+          onChange(nextValue);
+        }}
+        onBlur={(event) => {
+          const normalized = normalizeOnBlur(value, decimalPlaces);
+          if (normalized !== value) {
+            onChange(normalized);
+          }
+          onBlur?.(event);
+        }}
+        className={[
+          'input',
+          prefix ? 'pl-11' : '',
+          suffix ? 'pr-14' : '',
+          className,
+        ]
+          .filter(Boolean)
+          .join(' ')}
+      />
+      {suffix ? (
+        <span className="pointer-events-none absolute right-4 text-sm font-medium text-neutral">
+          {suffix}
+        </span>
+      ) : null}
+    </div>
+  );
+};

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -12,6 +12,26 @@ const config: Config = {
         sans: ['var(--font-inter)', 'Inter', 'system-ui', 'sans-serif'],
       },
       colors: {
+        primary: {
+          DEFAULT: 'hsl(var(--color-primary) / <alpha-value>)',
+          foreground: 'hsl(var(--color-primary-foreground) / <alpha-value>)',
+          muted: 'hsl(var(--color-primary-muted) / <alpha-value>)',
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--color-secondary) / <alpha-value>)',
+          foreground: 'hsl(var(--color-secondary-foreground) / <alpha-value>)',
+          muted: 'hsl(var(--color-secondary-muted) / <alpha-value>)',
+        },
+        neutral: {
+          DEFAULT: 'hsl(var(--color-neutral) / <alpha-value>)',
+          foreground: 'hsl(var(--color-neutral-foreground) / <alpha-value>)',
+          muted: 'hsl(var(--color-neutral-muted) / <alpha-value>)',
+        },
+        canvas: 'hsl(var(--color-canvas) / <alpha-value>)',
+        surface: 'hsl(var(--color-surface) / <alpha-value>)',
+        border: 'hsl(var(--color-border) / <alpha-value>)',
+        foreground: 'hsl(var(--color-text) / <alpha-value>)',
+        'muted-foreground': 'hsl(var(--color-muted-text) / <alpha-value>)',
         brand: {
           50:  '#f0fdf4',
           100: '#dcfce7',
@@ -34,8 +54,8 @@ const config: Config = {
         'glow-lg': '0 0 40px rgb(22 163 74 / 0.12)',
       },
       backgroundImage: {
-        'hero-gradient':    'linear-gradient(135deg, #f0fdf4 0%, #ffffff 50%, #ecfdf5 100%)',
-        'brand-gradient':   'linear-gradient(135deg, #16a34a 0%, #059669 100%)',
+        'hero-gradient':    'linear-gradient(135deg, hsl(var(--color-primary-muted)) 0%, hsl(var(--color-surface)) 45%, hsl(var(--color-secondary-muted)) 100%)',
+        'brand-gradient':   'linear-gradient(135deg, hsl(var(--color-primary)) 0%, hsl(var(--color-secondary)) 100%)',
         'dark-gradient':    'linear-gradient(135deg, #0f172a 0%, #1e293b 100%)',
         'card-gradient':    'linear-gradient(135deg, #ffffff 0%, #f8fafc 100%)',
         'shimmer-gradient': 'linear-gradient(90deg, #f1f5f9 25%, #e2e8f0 50%, #f1f5f9 75%)',


### PR DESCRIPTION
Closes #199
Closes #241
Closes #244
Closes #245

## Summary
- add a reusable `CurrencyInput` component with positive-decimal validation, thousands separators, and currency-specific precision handling
- cover USD and Stellar formatting behavior with focused component tests
- replace the generic Tailwind color setup with Agri-Fi branding tokens backed by CSS variables
- update shared global UI primitives to use the new primary, secondary, and neutral palette

## Testing
- not run locally because dependencies were not installed per request
