### PR TITLE
feat(investor-dashboard): delayed-deal warnings + Total Returns Paid metric (#252)

### DIFF
--- a/frontend/src/app/[locale]/dashboard/investor/page.tsx
+++ b/frontend/src/app/[locale]/dashboard/investor/page.tsx
@@ -44,6 +44,19 @@ export default function InvestorDashboard() {
   const totalTokens   = investments.reduce((s, i) => s + Number(i.token_holdings), 0);
   const totalExpected = investments.reduce((s, i) => s + Number(i.expected_return_usd), 0);
   const confirmed     = investments.filter(i => i.status === 'confirmed').length;
+  // "Total Returns Paid" = returns actually disbursed (actual_return_usd is set
+  // once a deal pays out); distinct from the projected "Expected Returns".
+  const totalReturnsPaid = investments.reduce((s, i) => s + Number(i.actual_return_usd ?? 0), 0);
+
+  // A funded deal is "delayed" once it is past its target maturity (delivery)
+  // date but has not yet been delivered, completed, or failed.
+  const isDealDelayed = (deal: Investment['deal']) => {
+    if (!deal.delivery_date) return false;
+    const due = new Date(deal.delivery_date).getTime();
+    if (Number.isNaN(due)) return false;
+    return Date.now() > due && !['delivered', 'completed', 'failed'].includes(deal.status);
+  };
+  const delayedCount = investments.filter(i => isDealDelayed(i.deal)).length;
 
   const filtered = filter === 'all' ? investments
     : investments.filter(i => i.status === filter);
@@ -71,12 +84,22 @@ export default function InvestorDashboard() {
           </div>
         </div>
 
+        {/* Delayed-deal warning: surfaces deals past their target maturity date. */}
+        {delayedCount > 0 && (
+          <div role="alert"
+            className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+            ⚠️ {delayedCount} of your funded deal{delayedCount !== 1 ? 's are' : ' is'} past
+            the target maturity date and not yet delivered. Review the flagged positions below.
+          </div>
+        )}
+
         {/* Stats */}
-        <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-          <StatCard label="Total Invested"   value={`${totalInvested.toLocaleString()}`}  icon="💰" color="bg-violet-50" />
-          <StatCard label="Confirmed"        value={confirmed}                              icon="✅" color="bg-emerald-50" />
-          <StatCard label="Total Tokens"     value={totalTokens.toLocaleString()}           icon="🪙" color="bg-blue-50" />
-          <StatCard label="Expected Returns" value={`${totalExpected.toLocaleString()}`}   icon="📈" color="bg-amber-50"
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
+          <StatCard label="Total Investment Value" value={`${totalInvested.toLocaleString()}`}  icon="💰" color="bg-violet-50" />
+          <StatCard label="Active Deals Funded"    value={confirmed}                              icon="✅" color="bg-emerald-50" />
+          <StatCard label="Total Returns Paid"     value={`${totalReturnsPaid.toLocaleString()}`} icon="💵" color="bg-teal-50" />
+          <StatCard label="Total Tokens"           value={totalTokens.toLocaleString()}           icon="🪙" color="bg-blue-50" />
+          <StatCard label="Expected Returns"       value={`${totalExpected.toLocaleString()}`}   icon="📈" color="bg-amber-50"
             trend={totalInvested > 0 ? `${((totalExpected / totalInvested - 1) * 100).toFixed(1)}% ROI` : undefined}
             trendUp={totalExpected > totalInvested} />
         </div>
@@ -156,6 +179,12 @@ export default function InvestorDashboard() {
                             <div className="flex flex-col items-end gap-1">
                               <span className={INV_STATUS[inv.status] ?? 'badge-gray'}>{inv.status}</span>
                               <span className={DEAL_STATUS[inv.deal.status] ?? 'badge-gray'}>{inv.deal.status}</span>
+                              {isDealDelayed(inv.deal) && (
+                                <span className="badge-red"
+                                  title={`Past target maturity date (${inv.deal.delivery_date})`}>
+                                  ⚠ Delayed
+                                </span>
+                              )}
                             </div>
                           </div>
 


### PR DESCRIPTION
## Summary

Completes the investor dashboard overview (#252). The page (`frontend/src/app/[locale]/dashboard/investor/page.tsx`) already rendered portfolio stat cards, a per-investment list, on-chain investment certificates and a fiat/USDC tab; this PR fills the acceptance-criteria gaps.

closes #252

## Changes
- **Metrics** — the stat row now names the required metrics: **Total Investment Value**, **Active Deals Funded**, and a new **Total Returns Paid** card (sum of `actual_return_usd`, i.e. returns actually disbursed — distinct from the existing projected **Expected Returns**). Tokens + Expected Returns are retained.
- **Delayed-deal warning state** (the main gap): a funded deal is flagged *delayed* once `Date.now()` is past its target maturity (`delivery_date`) and its status is not yet `delivered`/`completed`/`failed`. This surfaces as:
  - a top-of-page `role="alert"` banner with the count of delayed deals, and
  - a per-card **⚠ Delayed** badge (maturity date in the tooltip).
- Investment items remain clickable to the deal page (milestones) and the certificate (Stellar transaction hash), satisfying the "clickable details" criterion.

## Test plan
- `pnpm install` + `tsc --noEmit`: **no type errors in the changed file**. (A few pre-existing, unrelated errors exist elsewhere in the repo — `next/types` stubs, `Header.tsx`, `CurrencyInput.tsx`, `soroban.ts` — and were left untouched.)

## Caveats
- Logic-only additions to an existing page; no new dependencies, no data-layer changes (uses existing `Deal.delivery_date`, `Deal.status`, `Investment.actual_return_usd`).
- I couldn't run the dev server / visually QA in this environment; the change is type-checked and uses the established `StatCard` + badge conventions already in the file.
