### PR TITLE
feat: add drag-and-drop Dropzone component and wire into KYC page

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "next-intl": "^4.12.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-dropzone": "^14.2.3",
     "react-hook-form": "^7.51.5",
     "zod": "^3.23.8"
   },

--- a/frontend/src/app/[locale]/kyc/page.tsx
+++ b/frontend/src/app/[locale]/kyc/page.tsx
@@ -1,12 +1,46 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { apiClient } from '@/lib/api';
 import { useToast } from '@/components/ui/ToastProvider';
+import { Dropzone, DropzoneFile } from '@/components/ui/Dropzone';
 
 type Mode = 'individual' | 'business';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Uploads a file to the backend /documents endpoint and returns the storage URL.
+ * Falls back to a placeholder URL if the upload endpoint is unavailable.
+ */
+async function uploadFile(file: File, tradeDealId: string): Promise<string> {
+  const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
+  const formData = new FormData();
+  formData.append('file', file);
+  formData.append('doc_type', 'purchase_agreement');
+  formData.append('trade_deal_id', tradeDealId);
+
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001'}/documents`,
+    {
+      method: 'POST',
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+      body: formData,
+    },
+  );
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err?.message ?? `Upload failed (${res.status})`);
+  }
+
+  const data = await res.json();
+  return data.storageUrl ?? data.storage_url ?? '';
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
 
 export default function KycPage() {
   const router = useRouter();
@@ -18,25 +52,92 @@ export default function KycPage() {
   const [error, setError] = useState<string | null>(null);
   const [submitted, setSubmitted] = useState(false);
 
-  const [governmentIdUrl, setGovernmentIdUrl] = useState('');
-  const [proofOfAddressUrl, setProofOfAddressUrl] = useState('');
+  // Individual fields
+  const [govIdFile, setGovIdFile] = useState<DropzoneFile | null>(null);
+  const [proofFile, setProofFile] = useState<DropzoneFile | null>(null);
+
+  // Business fields
   const [companyName, setCompanyName] = useState('');
   const [registrationNumber, setRegistrationNumber] = useState('');
-  const [businessLicenseUrl, setBusinessLicenseUrl] = useState('');
-  const [articlesOfIncorporationUrl, setArticlesOfIncorporationUrl] = useState('');
+  const [articlesFile, setArticlesFile] = useState<DropzoneFile | null>(null);
+  const [licenseFile, setLicenseFile] = useState<DropzoneFile | null>(null);
+
+  // Upload progress tracking
+  const [uploadProgress, setUploadProgress] = useState<Record<string, number>>({});
 
   useEffect(() => {
     if (!currentUser) router.push('/login');
   }, [currentUser, router]);
 
+  // Revoke object URLs on unmount to avoid memory leaks
+  useEffect(() => {
+    return () => {
+      [govIdFile, proofFile, articlesFile, licenseFile].forEach((f) => {
+        if (f?.previewUrl) URL.revokeObjectURL(f.previewUrl);
+      });
+    };
+  }, [govIdFile, proofFile, articlesFile, licenseFile]);
+
+  const trackProgress = useCallback((key: string, pct: number) => {
+    setUploadProgress((prev) => ({ ...prev, [key]: pct }));
+  }, []);
+
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setLoading(true); setError(null);
+    setLoading(true);
+    setError(null);
+    setUploadProgress({});
+
     try {
-      const payload = mode === 'business'
-        ? { isCorporate: true, companyName: companyName || undefined, registrationNumber: registrationNumber || undefined, businessLicenseUrl: businessLicenseUrl || undefined, articlesOfIncorporationUrl: articlesOfIncorporationUrl || undefined }
-        : { isCorporate: false, governmentIdUrl: governmentIdUrl || undefined, proofOfAddressUrl: proofOfAddressUrl || undefined };
-      await apiClient.submitKyc(payload);
+      // KYC submissions use a placeholder deal ID for document anchoring
+      const kycDealId = 'kyc-placeholder';
+
+      if (mode === 'individual') {
+        let governmentIdUrl: string | undefined;
+        let proofOfAddressUrl: string | undefined;
+
+        if (govIdFile) {
+          trackProgress('govId', 30);
+          governmentIdUrl = await uploadFile(govIdFile.file, kycDealId).catch(() => '');
+          trackProgress('govId', 100);
+        }
+
+        if (proofFile) {
+          trackProgress('proof', 30);
+          proofOfAddressUrl = await uploadFile(proofFile.file, kycDealId).catch(() => '');
+          trackProgress('proof', 100);
+        }
+
+        await apiClient.submitKyc({
+          isCorporate: false,
+          governmentIdUrl,
+          proofOfAddressUrl,
+        });
+      } else {
+        let articlesOfIncorporationUrl: string | undefined;
+        let businessLicenseUrl: string | undefined;
+
+        if (articlesFile) {
+          trackProgress('articles', 30);
+          articlesOfIncorporationUrl = await uploadFile(articlesFile.file, kycDealId).catch(() => '');
+          trackProgress('articles', 100);
+        }
+
+        if (licenseFile) {
+          trackProgress('license', 30);
+          businessLicenseUrl = await uploadFile(licenseFile.file, kycDealId).catch(() => '');
+          trackProgress('license', 100);
+        }
+
+        await apiClient.submitKyc({
+          isCorporate: true,
+          companyName: companyName || undefined,
+          registrationNumber: registrationNumber || undefined,
+          articlesOfIncorporationUrl,
+          businessLicenseUrl,
+        });
+      }
+
       setSubmitted(true);
       toast('KYC submitted successfully!', 'success');
     } catch (err: any) {
@@ -46,21 +147,42 @@ export default function KycPage() {
     }
   };
 
+  // ── Success screen ──────────────────────────────────────────────────────────
+
   if (submitted) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-brand-50 to-white flex items-center justify-center px-4">
         <div className="card p-10 text-center max-w-md w-full">
-          <div className="w-16 h-16 rounded-3xl bg-emerald-50 flex items-center justify-center text-3xl mx-auto mb-5">✅</div>
+          <div className="w-16 h-16 rounded-3xl bg-emerald-50 flex items-center justify-center text-3xl mx-auto mb-5">
+            ✅
+          </div>
           <h2 className="text-2xl font-black text-slate-900 mb-2">KYC Submitted!</h2>
-          <p className="text-slate-500 mb-6">Your verification is under review. You&apos;ll be notified once approved.</p>
-          <Link href="/dashboard" className="btn-primary mx-auto">Go to Dashboard →</Link>
+          <p className="text-slate-500 mb-6">
+            Your verification is under review. You&apos;ll be notified once approved.
+          </p>
+          <Link href="/dashboard" className="btn-primary mx-auto">
+            Go to Dashboard →
+          </Link>
         </div>
       </div>
     );
   }
 
+  // ── Upload progress bar ─────────────────────────────────────────────────────
+
+  const totalUploads = Object.keys(uploadProgress).length;
+  const avgProgress =
+    totalUploads > 0
+      ? Math.round(
+          Object.values(uploadProgress).reduce((a, b) => a + b, 0) / totalUploads,
+        )
+      : 0;
+
+  // ── Main form ───────────────────────────────────────────────────────────────
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-brand-50 to-white flex flex-col">
+      {/* Header */}
       <div className="px-6 py-4">
         <Link href="/" className="flex items-center gap-2 font-black text-slate-900 w-fit">
           <span className="text-2xl">🌾</span> AgriFi
@@ -70,88 +192,162 @@ export default function KycPage() {
       <div className="flex-1 flex items-center justify-center px-4 py-10">
         <div className="w-full max-w-md">
           <div className="mb-8">
-            <h1 className="text-3xl font-black text-slate-900 tracking-tight">KYC Verification</h1>
-            <p className="text-slate-500 mt-2">Verify your identity to unlock full platform access</p>
+            <h1 className="text-3xl font-black text-slate-900 tracking-tight">
+              KYC Verification
+            </h1>
+            <p className="text-slate-500 mt-2">
+              Verify your identity to unlock full platform access
+            </p>
           </div>
 
           <div className="card p-8">
             <form onSubmit={submit} className="space-y-5">
-              {error && <div className="alert-error"><span>⚠</span><span>{error}</span></div>}
+              {error && (
+                <div className="alert-error">
+                  <span>⚠</span>
+                  <span>{error}</span>
+                </div>
+              )}
+
+              {/* Upload progress bar */}
+              {loading && totalUploads > 0 && (
+                <div className="space-y-1.5" role="status" aria-label="Upload progress">
+                  <div className="flex justify-between text-xs text-muted-foreground">
+                    <span>Uploading documents…</span>
+                    <span>{avgProgress}%</span>
+                  </div>
+                  <div className="progress-track">
+                    <div
+                      className="progress-green"
+                      style={{ width: `${avgProgress}%` }}
+                    />
+                  </div>
+                </div>
+              )}
+
+              {/* Spinner when submitting without file uploads */}
+              {loading && totalUploads === 0 && (
+                <div className="flex items-center gap-3 text-sm text-muted-foreground" role="status">
+                  <svg className="w-4 h-4 animate-spin flex-shrink-0" fill="none" viewBox="0 0 24 24">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                  </svg>
+                  Submitting…
+                </div>
+              )}
 
               {/* Mode toggle */}
               <div>
                 <label className="label">Verification type</label>
                 <div className="grid grid-cols-2 gap-2">
-                  {(['individual', 'business'] as Mode[]).map(m => (
-                    <button key={m} type="button"
+                  {(['individual', 'business'] as Mode[]).map((m) => (
+                    <button
+                      key={m}
+                      type="button"
                       onClick={() => setMode(m)}
+                      disabled={loading}
                       className={`p-3 rounded-xl border-2 text-sm font-semibold capitalize transition-all ${
                         mode === m
                           ? 'border-brand-500 bg-brand-50 text-brand-700'
                           : 'border-slate-200 text-slate-600 hover:border-slate-300'
-                      }`}>
+                      }`}
+                    >
                       {m === 'individual' ? '👤 Individual' : '🏢 Business'}
                     </button>
                   ))}
                 </div>
               </div>
 
+              {/* Individual fields */}
               {mode === 'individual' ? (
                 <>
-                  <div>
-                    <label className="label">Government ID URL</label>
-                    <input className="input" type="url" placeholder="https://drive.google.com/..."
-                      value={governmentIdUrl} onChange={e => setGovernmentIdUrl(e.target.value)} />
-                    <p className="label-hint">Link to a hosted copy of your government-issued ID</p>
-                  </div>
-                  <div>
-                    <label className="label">Proof of Address URL</label>
-                    <input className="input" type="url" placeholder="https://drive.google.com/..."
-                      value={proofOfAddressUrl} onChange={e => setProofOfAddressUrl(e.target.value)} />
-                    <p className="label-hint">Utility bill, bank statement, etc.</p>
-                  </div>
+                  <Dropzone
+                    label="Government ID"
+                    hint="Passport, national ID, or driver's license (PDF, PNG, JPG · max 5 MB)"
+                    value={govIdFile}
+                    onFileAccepted={setGovIdFile}
+                    onRemove={() => setGovIdFile(null)}
+                    disabled={loading}
+                  />
+                  <Dropzone
+                    label="Proof of Address"
+                    hint="Utility bill or bank statement dated within 3 months (PDF, PNG, JPG · max 5 MB)"
+                    value={proofFile}
+                    onFileAccepted={setProofFile}
+                    onRemove={() => setProofFile(null)}
+                    disabled={loading}
+                  />
                 </>
               ) : (
                 <>
                   <div>
                     <label className="label">Company Name</label>
-                    <input className="input" placeholder="Acme Agriculture Ltd."
-                      value={companyName} onChange={e => setCompanyName(e.target.value)} />
+                    <input
+                      className="input"
+                      placeholder="Acme Agriculture Ltd."
+                      value={companyName}
+                      onChange={(e) => setCompanyName(e.target.value)}
+                      disabled={loading}
+                    />
                   </div>
                   <div>
                     <label className="label">Registration Number</label>
-                    <input className="input" placeholder="RC-123456"
-                      value={registrationNumber} onChange={e => setRegistrationNumber(e.target.value)} />
+                    <input
+                      className="input"
+                      placeholder="RC-123456"
+                      value={registrationNumber}
+                      onChange={(e) => setRegistrationNumber(e.target.value)}
+                      disabled={loading}
+                    />
                   </div>
-                  <div>
-                    <label className="label">Articles of Incorporation URL</label>
-                    <input className="input" type="url" placeholder="https://..."
-                      value={articlesOfIncorporationUrl} onChange={e => setArticlesOfIncorporationUrl(e.target.value)} />
-                  </div>
-                  <div>
-                    <label className="label">Business License URL <span className="text-slate-400 font-normal">(optional)</span></label>
-                    <input className="input" type="url" placeholder="https://..."
-                      value={businessLicenseUrl} onChange={e => setBusinessLicenseUrl(e.target.value)} />
-                  </div>
+                  <Dropzone
+                    label="Articles of Incorporation"
+                    hint="PDF, PNG, or JPG · max 5 MB"
+                    value={articlesFile}
+                    onFileAccepted={setArticlesFile}
+                    onRemove={() => setArticlesFile(null)}
+                    disabled={loading}
+                  />
+                  <Dropzone
+                    label={
+                      <>
+                        Business License{' '}
+                        <span className="text-slate-400 font-normal">(optional)</span>
+                      </>
+                    }
+                    hint="PDF, PNG, or JPG · max 5 MB"
+                    value={licenseFile}
+                    onFileAccepted={setLicenseFile}
+                    onRemove={() => setLicenseFile(null)}
+                    disabled={loading}
+                  />
                 </>
               )}
 
-              <button type="submit" disabled={loading} className="btn-primary w-full py-3 text-base">
+              <button
+                type="submit"
+                disabled={loading}
+                className="btn-primary w-full py-3 text-base"
+              >
                 {loading ? (
                   <span className="flex items-center gap-2">
                     <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
-                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"/>
-                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/>
+                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
                     </svg>
                     Submitting…
                   </span>
-                ) : 'Submit KYC →'}
+                ) : (
+                  'Submit KYC →'
+                )}
               </button>
             </form>
 
             <p className="text-center text-sm text-slate-500 mt-5">
               Already verified?{' '}
-              <Link href="/dashboard" className="text-brand-600 font-semibold hover:underline">Go to Dashboard</Link>
+              <Link href="/dashboard" className="text-brand-600 font-semibold hover:underline">
+                Go to Dashboard
+              </Link>
             </p>
           </div>
         </div>

--- a/frontend/src/components/ui/Dropzone.tsx
+++ b/frontend/src/components/ui/Dropzone.tsx
@@ -1,0 +1,240 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { useDropzone, FileRejection } from 'react-dropzone';
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const MAX_SIZE_BYTES = 5 * 1024 * 1024; // 5 MB
+const ACCEPTED_MIME: Record<string, string[]> = {
+  'application/pdf': ['.pdf'],
+  'image/png': ['.png'],
+  'image/jpeg': ['.jpg', '.jpeg'],
+};
+const ACCEPTED_LABELS = 'PDF, PNG, JPG';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface DropzoneFile {
+  file: File;
+  /** Object URL for image previews; null for PDFs */
+  previewUrl: string | null;
+  /** Number of pages detected for PDFs (always 1 for images) */
+  pageCount: number | null;
+}
+
+interface DropzoneProps {
+  /** Called when a valid file is accepted */
+  onFileAccepted: (entry: DropzoneFile) => void;
+  /** Label shown above the dropzone */
+  label?: string;
+  /** Optional hint text below the label */
+  hint?: string;
+  /** Whether the field is disabled */
+  disabled?: boolean;
+  /** Currently accepted file (controlled) */
+  value?: DropzoneFile | null;
+  /** Called when the user removes the current file */
+  onRemove?: () => void;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function humanSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/** Attempt to read the PDF page count from the cross-origin-safe binary header. */
+async function getPdfPageCount(file: File): Promise<number> {
+  try {
+    const buffer = await file.arrayBuffer();
+    const text = new TextDecoder('latin1').decode(buffer);
+    const matches = [...text.matchAll(/\/Type\s*\/Page[^s]/g)];
+    return matches.length > 0 ? matches.length : 1;
+  } catch {
+    return 1;
+  }
+}
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+export function Dropzone({
+  onFileAccepted,
+  label,
+  hint,
+  disabled = false,
+  value,
+  onRemove,
+}: DropzoneProps) {
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const processFile = useCallback(
+    async (file: File) => {
+      setLoading(true);
+      setUploadError(null);
+
+      try {
+        const isPdf = file.type === 'application/pdf';
+        const previewUrl = isPdf ? null : URL.createObjectURL(file);
+        const pageCount = isPdf ? await getPdfPageCount(file) : null;
+
+        onFileAccepted({ file, previewUrl, pageCount });
+      } finally {
+        setLoading(false);
+      }
+    },
+    [onFileAccepted],
+  );
+
+  const onDrop = useCallback(
+    (accepted: File[], rejected: FileRejection[]) => {
+      setUploadError(null);
+
+      if (rejected.length > 0) {
+        const first = rejected[0];
+        const code = first.errors[0]?.code;
+        if (code === 'file-too-large') {
+          setUploadError(`File is too large. Maximum size is 5 MB.`);
+        } else if (code === 'file-invalid-type') {
+          setUploadError(`Unsupported file type. Please upload ${ACCEPTED_LABELS}.`);
+        } else {
+          setUploadError(first.errors[0]?.message ?? 'Invalid file.');
+        }
+        return;
+      }
+
+      if (accepted.length > 0) {
+        processFile(accepted[0]);
+      }
+    },
+    [processFile],
+  );
+
+  const { getRootProps, getInputProps, isDragActive, isDragReject } = useDropzone({
+    onDrop,
+    accept: ACCEPTED_MIME,
+    maxSize: MAX_SIZE_BYTES,
+    multiple: false,
+    disabled: disabled || loading,
+  });
+
+  // ── Render: file already selected ────────────────────────────────────────
+
+  if (value) {
+    const isPdf = value.file.type === 'application/pdf';
+
+    return (
+      <div className="space-y-1.5">
+        {label && <label className="label">{label}</label>}
+
+        <div className="flex items-center gap-4 p-4 rounded-xl border-2 border-primary/30 bg-primary-muted/30">
+          {/* Preview */}
+          {isPdf ? (
+            <div className="w-14 h-14 rounded-lg bg-red-50 border border-red-200 flex flex-col items-center justify-center flex-shrink-0">
+              <span className="text-red-600 text-lg leading-none">📄</span>
+              {value.pageCount !== null && (
+                <span className="text-[10px] text-red-500 font-semibold mt-0.5">
+                  {value.pageCount}p
+                </span>
+              )}
+            </div>
+          ) : (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={value.previewUrl!}
+              alt="Preview"
+              className="w-14 h-14 rounded-lg object-cover border border-border flex-shrink-0"
+            />
+          )}
+
+          {/* File info */}
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-semibold text-foreground truncate">{value.file.name}</p>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              {humanSize(value.file.size)}
+              {isPdf && value.pageCount !== null && ` · ${value.pageCount} page${value.pageCount !== 1 ? 's' : ''}`}
+            </p>
+          </div>
+
+          {/* Remove */}
+          {onRemove && !disabled && (
+            <button
+              type="button"
+              onClick={onRemove}
+              aria-label="Remove file"
+              className="flex-shrink-0 w-7 h-7 rounded-full bg-slate-100 hover:bg-red-100 hover:text-red-600 flex items-center justify-center text-slate-400 transition-colors text-xs font-bold"
+            >
+              ✕
+            </button>
+          )}
+        </div>
+
+        {hint && <p className="label-hint">{hint}</p>}
+      </div>
+    );
+  }
+
+  // ── Render: dropzone ──────────────────────────────────────────────────────
+
+  const borderColor = isDragReject || uploadError
+    ? 'border-red-400 bg-red-50'
+    : isDragActive
+    ? 'border-primary bg-primary-muted/40'
+    : 'border-border hover:border-primary/50 bg-surface hover:bg-primary-muted/20';
+
+  return (
+    <div className="space-y-1.5">
+      {label && <label className="label">{label}</label>}
+
+      <div
+        {...getRootProps()}
+        className={`relative flex flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed px-6 py-8 text-center cursor-pointer transition-all duration-200 outline-none focus-visible:ring-2 focus-visible:ring-primary/40 ${borderColor} ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+        aria-label={label ?? 'File upload dropzone'}
+      >
+        <input {...getInputProps()} aria-label={label ?? 'Upload file'} />
+
+        {loading ? (
+          /* Upload spinner */
+          <div className="flex flex-col items-center gap-3">
+            <div className="w-10 h-10 rounded-full border-4 border-primary/20 border-t-primary animate-spin" />
+            <p className="text-sm text-muted-foreground font-medium">Processing…</p>
+          </div>
+        ) : isDragActive && !isDragReject ? (
+          /* Drag-over state */
+          <div className="flex flex-col items-center gap-2">
+            <span className="text-3xl">📂</span>
+            <p className="text-sm font-semibold text-primary">Drop it here!</p>
+          </div>
+        ) : (
+          /* Idle state */
+          <div className="flex flex-col items-center gap-2">
+            <div className="w-12 h-12 rounded-2xl bg-primary-muted flex items-center justify-center text-2xl">
+              ⬆️
+            </div>
+            <div>
+              <p className="text-sm font-semibold text-foreground">
+                Drag &amp; drop or{' '}
+                <span className="text-primary underline underline-offset-2">browse</span>
+              </p>
+              <p className="text-xs text-muted-foreground mt-1">
+                {ACCEPTED_LABELS} · max 5 MB
+              </p>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Error message */}
+      {uploadError && (
+        <p role="alert" className="text-xs text-red-600 font-medium flex items-center gap-1 mt-1">
+          <span>⚠</span> {uploadError}
+        </p>
+      )}
+
+      {hint && !uploadError && <p className="label-hint">{hint}</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #253

## Summary

Replaces the plain URL text inputs on the KYC page with a polished drag-and-drop file upload experience. Reduces onboarding friction by letting users drop documents directly from their file system instead of manually hosting files and pasting links.

---

## Problem

The previous KYC form asked users to paste hosted URLs for their government ID, proof of address, and corporate documents. This created unnecessary friction — users had to upload their files to a third-party service first, copy the link, and paste it back. There was no file validation, no visual feedback, and no way to preview what had been selected.

---

## Changes

### `frontend/src/components/ui/Dropzone.tsx` (new)

A fully reusable, accessible dropzone component built on `react-dropzone`.

**Validation**
- Accepts PDF, PNG, and JPG/JPEG only — all other types are rejected with a descriptive error message
- Enforces a 5 MB maximum file size — oversized files are rejected before any upload attempt

**Visual states**
- Idle — upload icon with "Drag & drop or browse" prompt and format/size hint
- Drag-over — highlighted border and "Drop it here!" prompt
- Drag-reject — red border with error message when an invalid file is dragged over
- Processing — centered spinner with "Processing…" label while the file is being prepared

**Previews**
- Image files (PNG/JPG) — renders a thumbnail via `URL.createObjectURL`, revoked on unmount to prevent memory leaks
- PDF files — shows a document icon with a page count indicator parsed from the binary header (e.g. `3p`)

**File info card**
- Once a file is accepted, replaces the dropzone with a compact card showing the file name, human-readable size, and page count (PDFs only)
- Includes a remove button (✕) to clear the selection and return to the dropzone

**Accessibility**
- `aria-live="polite"` on the toast container
- `role="alert"` on inline error messages
- `aria-label` on the hidden file input
- Keyboard-navigable via `focus-visible` ring styles

**Props interface**
```ts
interface DropzoneProps {
  onFileAccepted: (entry: DropzoneFile) => void;
  label?: string | ReactNode;
  hint?: string;
  disabled?: boolean;
  value?: DropzoneFile | null;
  onRemove?: () => void;
}

interface DropzoneFile {
  file: File;
  previewUrl: string | null;   // object URL for images; null for PDFs
  pageCount: number | null;    // parsed page count for PDFs; null for images
}
