### PR TITLE
feat: add dynamic OG metadata to marketplace deal pages

### DIFF
--- a/frontend/src/app/[locale]/marketplace/[id]/page.tsx
+++ b/frontend/src/app/[locale]/marketplace/[id]/page.tsx
@@ -11,13 +11,75 @@ import InvestmentSection from '@/components/InvestmentSection';
 export const dynamic = 'force-dynamic';
 export const revalidate = 60;
 
-export async function generateMetadata({ params }: { params: { id: string } }): Promise<Metadata> {
+export async function generateMetadata({
+  params,
+}: {
+  params: { id: string; locale: string };
+}): Promise<Metadata> {
   try {
     const deal = await getDealById(params.id);
     if (!deal) return { title: 'Deal Not Found | AgriFi' };
-    const title = `${deal.commodity.charAt(0).toUpperCase() + deal.commodity.slice(1)} — AgriFi`;
-    const description = `${deal.quantity} ${deal.quantity_unit} of ${deal.commodity}. Total value $${Number(deal.total_value).toLocaleString()}.`;
-    return { title, description };
+
+    const commodity =
+      deal.commodity.charAt(0).toUpperCase() + deal.commodity.slice(1);
+    const totalValue = Number(deal.total_value);
+    const totalInvested = Number(deal.total_invested);
+
+    const fundingPct =
+      totalValue > 0
+        ? Math.min(Math.round((totalInvested / totalValue) * 100), 100)
+        : 0;
+
+    // Estimated ROI: platform distributes 98% of deal value to investors.
+    const roi =
+      totalInvested > 0
+        ? ((totalValue * 0.98 - totalInvested) / totalInvested) * 100
+        : 0;
+    const roiLabel =
+      roi > 0 ? `+${roi.toFixed(1)}% target ROI` : 'Earn returns on delivery';
+
+    const title = `Invest in ${commodity} — $${totalValue.toLocaleString()} USD | AgriFi`;
+    const description =
+      `${Number(deal.quantity).toLocaleString()} ${deal.quantity_unit} of ${commodity}. ` +
+      `${fundingPct}% funded · ${roiLabel}. ` +
+      `Delivery by ${new Date(deal.delivery_date).toLocaleDateString('en', {
+        month: 'long',
+        day: 'numeric',
+        year: 'numeric',
+      })}.`;
+
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'https://agri-fi.app';
+    const pageUrl = `${appUrl}/marketplace/${deal.id}`;
+    const ogImage = `${appUrl}/og-default.png`;
+
+    return {
+      title,
+      description,
+      openGraph: {
+        type: 'website',
+        url: pageUrl,
+        siteName: 'AgriFi',
+        title,
+        description,
+        images: [
+          {
+            url: ogImage,
+            width: 1200,
+            height: 630,
+            alt: `${commodity} trade deal on AgriFi`,
+          },
+        ],
+      },
+      twitter: {
+        card: 'summary_large_image',
+        title,
+        description,
+        images: [ogImage],
+      },
+      alternates: {
+        canonical: pageUrl,
+      },
+    };
   } catch {
     return { title: 'Trade Deal | AgriFi' };
   }


### PR DESCRIPTION
Closes #261 

## Summary

Adds dynamic Open Graph and Twitter Card metadata to marketplace deal detail pages so that sharing a deal link on LinkedIn, Twitter, or any OG-aware platform renders a rich preview with the deal's commodity, funding progress, target ROI, and delivery date instead of a blank or generic card.

## Problem

The previous `generateMetadata` implementation produced a minimal title and a plain description with no Open Graph or Twitter Card tags. Sharing a deal URL on social media resulted in an unformatted link with no image, no structured data, and no call to action — making it ineffective for attracting institutional investors.

## Changes

### `frontend/src/app/[locale]/marketplace/[id]/page.tsx`

The `generateMetadata` function was rewritten to fetch the deal from the API and derive all metadata fields from live deal data.

**Title format**
Invest in [Commodity] — $[Total Value] USD | AgriFi

**Description format**
[Quantity] [Unit] of [Commodity]. [X]% funded · [ROI label]. Delivery by [Date]


**Funding progress** is calculated as `min(round((totalInvested / totalValue) × 100), 100)`.

**Target ROI** is derived from the platform's 98% payout model: `((totalValue × 0.98 − totalInvested) / totalInvested) × 100`. Displayed as `+X.X% target ROI` when positive, or `Earn returns on delivery` when no investment has been made yet.

**Open Graph tags**

| Tag | Value |
|---|---|
| `og:type` | `website` |
| `og:url` | `{NEXT_PUBLIC_APP_URL}/marketplace/{id}` |
| `og:site_name` | `AgriFi` |
| `og:title` | Deal title |
| `og:description` | Deal description |
| `og:image` | `{NEXT_PUBLIC_APP_URL}/og-default.png` (1200×630) |
| `og:image:alt` | `[Commodity] trade deal on AgriFi` |

**Twitter Card tags**

| Tag | Value |
|---|---|
| `twitter:card` | `summary_large_image` |
| `twitter:title` | Deal title |
| `twitter:description` | Deal description |
| `twitter:image` | Same OG image URL |

**Canonical URL** — `alternates.canonical` is set to the deal's full page URL to prevent duplicate content issues across locales.

**Error handling** — any fetch failure or missing deal falls back gracefully to `{ title: 'Trade Deal | AgriFi' }`.

## Environment Variables

| Variable | Description | Default |
|---|---|---|
| `NEXT_PUBLIC_APP_URL` | Base URL for canonical and OG image links | `https://agri-fi.app` |

Add a static `og-default.png` (1200×630) to `frontend/public/` to populate the image tag. A deal-specific dynamic OG image via `next/og` can be added as a follow-up.
