### PR TITLE
feat: integrate Sentry for frontend error tracking and source maps

### DIFF
--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,6 +1,12 @@
 NEXT_PUBLIC_API_URL=http://localhost:3001
 BACKEND_URL=http://localhost:3001
 
+# Sentry error tracking
+NEXT_PUBLIC_SENTRY_DSN=
+SENTRY_ORG=
+SENTRY_PROJECT=
+SENTRY_AUTH_TOKEN=
+
 # Stellar network (testnet or mainnet)
 NEXT_PUBLIC_STELLAR_NETWORK=testnet
 

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,4 +1,5 @@
 const createNextIntlPlugin = require('next-intl/plugin');
+const { withSentryConfig } = require('@sentry/nextjs');
 
 const withNextIntl = createNextIntlPlugin();
 
@@ -7,8 +8,32 @@ const nextConfig = {
   reactStrictMode: true,
   env: {
     NEXT_PUBLIC_API_URL:
-      process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001",
+      process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001',
   },
 };
 
-module.exports = withNextIntl(nextConfig);
+const withIntl = withNextIntl(nextConfig);
+
+module.exports = withSentryConfig(withIntl, {
+  // Sentry organisation and project (set in CI / Vercel env vars)
+  org: process.env.SENTRY_ORG,
+  project: process.env.SENTRY_PROJECT,
+
+  // Auth token for source map uploads — set SENTRY_AUTH_TOKEN in CI
+  authToken: process.env.SENTRY_AUTH_TOKEN,
+
+  // Upload source maps only during production builds
+  silent: true,
+  hideSourceMaps: true,
+
+  // Automatically tree-shake Sentry logger statements in production
+  disableLogger: true,
+
+  // Widen the tunnel route to avoid ad-blocker interference
+  tunnelRoute: '/monitoring',
+
+  // Automatically instrument Next.js data fetching methods
+  autoInstrumentServerFunctions: true,
+  autoInstrumentMiddleware: true,
+  autoInstrumentAppDirectory: true,
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.6.0",
+    "@sentry/nextjs": "^8.0.0",
     "@stellar/freighter-api": "^2.0.0",
     "axios": "^1.6.0",
     "framer-motion": "^12.40.0",

--- a/frontend/sentry.client.config.js
+++ b/frontend/sentry.client.config.js
@@ -1,0 +1,42 @@
+import * as Sentry from '@sentry/nextjs';
+
+Sentry.init({
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+
+  // Only enable Sentry in production to avoid noise during development
+  enabled: process.env.NODE_ENV === 'production',
+
+  // Capture 10% of transactions for performance monitoring
+  tracesSampleRate: 0.1,
+
+  // Capture 100% of sessions that include an error for session replay
+  replaysOnErrorSampleRate: 1.0,
+
+  // Capture 1% of all sessions for baseline session replay
+  replaysSessionSampleRate: 0.01,
+
+  integrations: [
+    Sentry.replayIntegration({
+      // Mask all text and block all media in replays to protect user privacy
+      maskAllText: true,
+      blockAllMedia: true,
+    }),
+  ],
+
+  // Ignore common browser noise that isn't actionable
+  ignoreErrors: [
+    'ResizeObserver loop limit exceeded',
+    'ResizeObserver loop completed with undelivered notifications',
+    /^Network Error$/,
+    /^Failed to fetch$/,
+    /^Load failed$/,
+  ],
+
+  beforeSend(event) {
+    // Drop events with no stack trace (e.g. browser extensions)
+    if (!event.exception?.values?.[0]?.stacktrace?.frames?.length) {
+      return null;
+    }
+    return event;
+  },
+});

--- a/frontend/src/app/[locale]/layout.tsx
+++ b/frontend/src/app/[locale]/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "../globals.css";
+import * as Sentry from "@sentry/nextjs";
 import { ToastProvider } from "@/components/ui/ToastProvider";
 import { NextIntlClientProvider } from 'next-intl';
 import { getMessages } from 'next-intl/server';
@@ -22,9 +23,48 @@ export default async function RootLayout({
     <html lang={locale}>
       <body>
         <NextIntlClientProvider messages={messages}>
-          <ToastProvider>
-            {children}
-          </ToastProvider>
+          <Sentry.ErrorBoundary
+            fallback={({ error, resetError }) => (
+              <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+                <div className="bg-white rounded-xl shadow-lg p-8 max-w-md w-full text-center border border-gray-100">
+                  <div className="bg-red-50 rounded-full w-16 h-16 flex items-center justify-center mx-auto mb-5">
+                    <svg
+                      className="w-8 h-8 text-red-500"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                      aria-hidden="true"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                      />
+                    </svg>
+                  </div>
+                  <h2 className="text-xl font-semibold text-gray-900 mb-3">
+                    Something went wrong
+                  </h2>
+                  <p className="text-gray-600 mb-8 text-sm">
+                    We encountered an unexpected error. Our team has been notified.
+                  </p>
+                  <button
+                    onClick={resetError}
+                    className="bg-green-600 hover:bg-green-700 text-white font-medium px-6 py-2.5 rounded-lg transition-colors w-full focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
+                    autoFocus
+                  >
+                    Try again
+                  </button>
+                </div>
+              </div>
+            )}
+            showDialog
+          >
+            <ToastProvider>
+              {children}
+            </ToastProvider>
+          </Sentry.ErrorBoundary>
         </NextIntlClientProvider>
       </body>
     </html>


### PR DESCRIPTION
Closes #265 

## Summary

Integrates Sentry into the Next.js frontend for real-time tracking of uncaught JavaScript exceptions, frontend API failures, and performance issues in production. Covers client-side initialisation, source map uploads in the build pipeline, and a root-level error boundary that reports crashes automatically.

## Problem

The frontend had no error monitoring in production. Uncaught exceptions and API failures were silently swallowed or logged only to the browser console, making it impossible to detect, triage, or reproduce issues affecting real users. The existing `ErrorBoundary` component logged errors with `console.error` but never reported them anywhere.

## Changes

### `frontend/sentry.client.config.js` (new)

Initialises the Sentry SDK on the client side.

- `dsn` reads from `NEXT_PUBLIC_SENTRY_DSN` — no DSN means no data is sent
- `enabled: process.env.NODE_ENV === 'production'` — Sentry is completely inactive in development and test environments to avoid noise
- `tracesSampleRate: 0.1` — captures 10% of transactions for performance monitoring
- `replaysOnErrorSampleRate: 1.0` — captures a full session replay for every session that includes an error
- `replaysSessionSampleRate: 0.01` — captures 1% of all sessions as a baseline
- `SessionReplay` integration configured with `maskAllText: true` and `blockAllMedia: true` to protect user privacy in replays
- `ignoreErrors` filters out browser-extension noise (`ResizeObserver loop`, `Network Error`, `Failed to fetch`, `Load failed`) that is not actionable
- `beforeSend` drops events with no stack trace frames, which are almost always caused by third-party browser extensions rather than application code

### `frontend/next.config.js` (updated)

Wraps the existing Next.js config with `withSentryConfig` to integrate Sentry into the build pipeline.

- `authToken` reads from `SENTRY_AUTH_TOKEN` — set this in CI (Vercel, GitHub Actions, etc.) to enable source map uploads
- `hideSourceMaps: true` — source maps are uploaded to Sentry but excluded from the client bundle so application code is not exposed in production
- `silent: true` — suppresses Sentry CLI output during builds
- `disableLogger: true` — tree-shakes Sentry logger statements from the production bundle to reduce bundle size
- `tunnelRoute: '/monitoring'` — proxies Sentry requests through the Next.js server to bypass ad-blockers that block `sentry.io` directly
- `autoInstrumentServerFunctions: true` — automatically wraps API routes and server actions
- `autoInstrumentMiddleware: true` — instruments Next.js middleware
- `autoInstrumentAppDirectory: true` — instruments App Router server components

### `frontend/src/app/[locale]/layout.tsx` (updated)

Wraps the entire application tree with `Sentry.ErrorBoundary` so any uncaught render error is captured and reported automatically.

- Placed outside `ToastProvider` so it catches errors thrown by any child, including the toast system itself
- Fallback UI matches the existing design system (same card, icon, and button styles as the existing `ErrorBoundary` component)
- `resetError` prop wired to the "Try again" button so users can attempt to recover without a full page reload
- `showDialog: true` opens Sentry's user feedback dialog on error, allowing users to describe what they were doing when the crash occurred

### `frontend/package.json` (updated)

Added `@sentry/nextjs ^8.0.0` to `dependencies`.

### `frontend/.env.local.example` (updated)

Documented the four new environment variables required for Sentry.

## Environment Variables

| Variable | Where it's used | Required in prod |
|---|---|---|
| `NEXT_PUBLIC_SENTRY_DSN` | `sentry.client.config.js` — identifies the Sentry project | Yes |
| `SENTRY_ORG` | `next.config.js` — Sentry organisation slug for source map uploads | Yes |
| `SENTRY_PROJECT` | `next.config.js` — Sentry project slug for source map uploads | Yes |
| `SENTRY_AUTH_TOKEN` | `next.config.js` — auth token for the Sentry CLI | Yes |

All four variables should be added as secrets in the CI/CD environment (Vercel, GitHub Actions, etc.). The app starts and runs normally without them — Sentry is simply inactive.
