### PR TITLE
feat: add printable deal receipt page with A4 print styles

### DIFF
--- a/frontend/src/app/deals/[id]/receipt/page.tsx
+++ b/frontend/src/app/deals/[id]/receipt/page.tsx
@@ -1,0 +1,415 @@
+'use client';
+
+import './print.css';
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { getDealById, Deal, getStoredToken } from '@/lib/api';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface PaymentDistribution {
+  id: string;
+  recipient_type: 'farmer' | 'investor' | 'platform';
+  recipient_id: string | null;
+  wallet_address: string;
+  amount_usd: number;
+  stellar_tx_id: string | null;
+  status: 'confirmed' | 'failed';
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function fmt(n: number): string {
+  return n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+
+function shortHash(hash: string | null | undefined, len = 16): string {
+  if (!hash) return '—';
+  return hash.length > len * 2 + 3
+    ? `${hash.slice(0, len)}…${hash.slice(-8)}`
+    : hash;
+}
+
+function statusBannerClass(status: string): string {
+  if (status === 'completed') return 'receipt-status-banner completed';
+  if (status === 'delivered') return 'receipt-status-banner delivered';
+  if (status === 'funded') return 'receipt-status-banner funded';
+  return 'receipt-status-banner other';
+}
+
+function statusLabel(status: string): string {
+  const map: Record<string, string> = {
+    completed: '✅ Deal Completed — Escrow Released',
+    delivered: '🚚 Delivered — Awaiting Escrow Release',
+    funded: '💰 Fully Funded — Shipment in Progress',
+    open: '🟢 Open for Investment',
+    draft: '📝 Draft',
+    failed: '❌ Failed',
+  };
+  return map[status] ?? status;
+}
+
+const MILESTONE_LABELS: Record<string, string> = {
+  farm: 'Farm Collection',
+  warehouse: 'Warehouse Storage',
+  port: 'Port Departure',
+  importer: 'Importer Delivery',
+};
+
+const HORIZON_BASE = 'https://stellar.expert/explorer/testnet/tx';
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export default function ReceiptPage({ params }: { params: { id: string } }) {
+  const [deal, setDeal] = useState<Deal | null>(null);
+  const [distributions, setDistributions] = useState<PaymentDistribution[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const d = await getDealById(params.id);
+        if (!d) { setError('Deal not found.'); return; }
+        setDeal(d);
+
+        // Fetch payment distributions if the deal is completed
+        if (d.status === 'completed') {
+          const token = getStoredToken();
+          const res = await fetch(
+            `${process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001'}/escrow/distributions/${params.id}`,
+            { headers: token ? { Authorization: `Bearer ${token}` } : {} },
+          );
+          if (res.ok) {
+            const raw = await res.json();
+            const list: PaymentDistribution[] = (Array.isArray(raw) ? raw : raw.data ?? []).map(
+              (p: any) => ({
+                id: p.id,
+                recipient_type: p.recipientType ?? p.recipient_type,
+                recipient_id: p.recipientId ?? p.recipient_id ?? null,
+                wallet_address: p.walletAddress ?? p.wallet_address ?? '',
+                amount_usd: Number(p.amountUsd ?? p.amount_usd ?? 0),
+                stellar_tx_id: p.stellarTxId ?? p.stellar_tx_id ?? null,
+                status: p.status ?? 'confirmed',
+              }),
+            );
+            setDistributions(list);
+          }
+        }
+      } catch (err: any) {
+        setError(err?.message ?? 'Failed to load receipt.');
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [params.id]);
+
+  // ── Loading ─────────────────────────────────────────────────────────────────
+
+  if (loading) {
+    return (
+      <div className="receipt-page" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <div style={{ textAlign: 'center', color: '#94a3b8' }}>
+          <div style={{ width: 40, height: 40, border: '3px solid #e2e8f0', borderTopColor: '#166534', borderRadius: '50%', animation: 'spin 0.8s linear infinite', margin: '0 auto 1rem' }} />
+          <p style={{ fontSize: '0.875rem' }}>Loading receipt…</p>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Error ───────────────────────────────────────────────────────────────────
+
+  if (error || !deal) {
+    return (
+      <div className="receipt-page" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <div style={{ textAlign: 'center', maxWidth: 360 }}>
+          <p style={{ fontSize: '2rem', marginBottom: '0.75rem' }}>⚠️</p>
+          <p style={{ fontWeight: 700, marginBottom: '0.5rem' }}>Receipt unavailable</p>
+          <p style={{ fontSize: '0.875rem', color: '#64748b', marginBottom: '1.5rem' }}>{error ?? 'Deal not found.'}</p>
+          <Link href="/marketplace" className="btn-back">← Back to Marketplace</Link>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Derived values ──────────────────────────────────────────────────────────
+
+  const totalValue = Number(deal.total_value);
+  const farmerPayout = distributions.find(d => d.recipient_type === 'farmer');
+  const platformPayout = distributions.find(d => d.recipient_type === 'platform');
+  const investorPayouts = distributions.filter(d => d.recipient_type === 'investor');
+  const generatedAt = new Date().toLocaleString('en-US', {
+    dateStyle: 'long', timeStyle: 'short',
+  });
+
+  // ── Render ──────────────────────────────────────────────────────────────────
+
+  return (
+    <div className="receipt-page">
+
+      {/* Toolbar — hidden on print */}
+      <div className="receipt-toolbar no-print">
+        <Link href={`/marketplace/${deal.id}`} className="btn-back">
+          <svg width="14" height="14" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+          </svg>
+          Back to Deal
+        </Link>
+        <div className="receipt-toolbar-actions">
+          <span style={{ fontSize: '0.8125rem', color: '#94a3b8' }}>
+            Deal #{deal.id.slice(0, 8).toUpperCase()}
+          </span>
+          <button
+            className="btn-print"
+            onClick={() => window.print()}
+            aria-label="Print this receipt"
+          >
+            <svg width="15" height="15" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 9V2h12v7M6 18H4a2 2 0 01-2-2v-5a2 2 0 012-2h16a2 2 0 012 2v5a2 2 0 01-2 2h-2M6 14h12v8H6v-8z" />
+            </svg>
+            Print Receipt
+          </button>
+        </div>
+      </div>
+
+      {/* A4 document */}
+      <div className="receipt-wrapper">
+        <div className="receipt-document">
+
+          {/* Header */}
+          <div className="receipt-header">
+            <div className="receipt-brand">
+              <span className="receipt-brand-icon">🌾</span>
+              AgriFi
+            </div>
+            <div className="receipt-meta">
+              <h1 className="receipt-title">Payment Receipt</h1>
+              <p className="receipt-subtitle">
+                {deal.id.toUpperCase()}
+              </p>
+            </div>
+          </div>
+
+          {/* Status banner */}
+          <div className={statusBannerClass(deal.status)}>
+            {statusLabel(deal.status)}
+          </div>
+
+          {/* Deal summary */}
+          <div className="receipt-section">
+            <p className="receipt-section-title">Deal Summary</p>
+            <div className="receipt-grid">
+              <div className="receipt-field">
+                <span className="receipt-field-label">Commodity</span>
+                <span className="receipt-field-value" style={{ textTransform: 'capitalize' }}>
+                  {deal.commodity}
+                </span>
+              </div>
+              <div className="receipt-field">
+                <span className="receipt-field-label">Token Symbol</span>
+                <span className="receipt-field-value mono">{deal.token_symbol}</span>
+              </div>
+              <div className="receipt-field">
+                <span className="receipt-field-label">Quantity</span>
+                <span className="receipt-field-value">
+                  {Number(deal.quantity).toLocaleString()} {deal.quantity_unit}
+                </span>
+              </div>
+              <div className="receipt-field">
+                <span className="receipt-field-label">Delivery Date</span>
+                <span className="receipt-field-value">
+                  {new Date(deal.delivery_date).toLocaleDateString('en-US', {
+                    year: 'numeric', month: 'long', day: 'numeric',
+                  })}
+                </span>
+              </div>
+              <div className="receipt-field">
+                <span className="receipt-field-label">Total Deal Value</span>
+                <span className="receipt-field-value large">${fmt(totalValue)} USD</span>
+              </div>
+              <div className="receipt-field">
+                <span className="receipt-field-label">Status</span>
+                <span className="receipt-field-value" style={{ textTransform: 'capitalize' }}>
+                  {deal.status}
+                </span>
+              </div>
+              {deal.issuer_public_key && (
+                <div className="receipt-field receipt-grid-wide">
+                  <span className="receipt-field-label">Token Issuer (Stellar)</span>
+                  <span className="receipt-field-value mono">{deal.issuer_public_key}</span>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Payment distributions — only shown when completed */}
+          {distributions.length > 0 && (
+            <div className="receipt-section">
+              <p className="receipt-section-title">Payment Distributions</p>
+              <table className="receipt-table">
+                <thead>
+                  <tr>
+                    <th>Recipient</th>
+                    <th>Wallet Address</th>
+                    <th>Stellar TX</th>
+                    <th>Amount (USD)</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {/* Farmer */}
+                  {farmerPayout && (
+                    <tr>
+                      <td style={{ fontWeight: 600 }}>🌾 Farmer (98%)</td>
+                      <td className="mono">{shortHash(farmerPayout.wallet_address, 12)}</td>
+                      <td className="mono">
+                        {farmerPayout.stellar_tx_id ? (
+                          <a
+                            href={`${HORIZON_BASE}/${farmerPayout.stellar_tx_id}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            style={{ color: '#166534' }}
+                          >
+                            {shortHash(farmerPayout.stellar_tx_id)}
+                          </a>
+                        ) : '—'}
+                      </td>
+                      <td className="amount">${fmt(farmerPayout.amount_usd)}</td>
+                    </tr>
+                  )}
+
+                  {/* Investors */}
+                  {investorPayouts.map((inv, i) => (
+                    <tr key={inv.id}>
+                      <td style={{ fontWeight: 600 }}>💼 Investor {i + 1}</td>
+                      <td className="mono">{shortHash(inv.wallet_address, 12)}</td>
+                      <td className="mono">
+                        {inv.stellar_tx_id ? (
+                          <a
+                            href={`${HORIZON_BASE}/${inv.stellar_tx_id}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            style={{ color: '#166534' }}
+                          >
+                            {shortHash(inv.stellar_tx_id)}
+                          </a>
+                        ) : '—'}
+                      </td>
+                      <td className="amount">${fmt(inv.amount_usd)}</td>
+                    </tr>
+                  ))}
+
+                  {/* Platform fee */}
+                  {platformPayout && (
+                    <tr>
+                      <td style={{ fontWeight: 600 }}>🏛 Platform Fee (2%)</td>
+                      <td className="mono">{shortHash(platformPayout.wallet_address, 12)}</td>
+                      <td className="mono">
+                        {platformPayout.stellar_tx_id ? (
+                          <a
+                            href={`${HORIZON_BASE}/${platformPayout.stellar_tx_id}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            style={{ color: '#166534' }}
+                          >
+                            {shortHash(platformPayout.stellar_tx_id)}
+                          </a>
+                        ) : '—'}
+                      </td>
+                      <td className="amount">${fmt(platformPayout.amount_usd)}</td>
+                    </tr>
+                  )}
+                </tbody>
+                <tfoot>
+                  <tr>
+                    <td colSpan={3} style={{ fontWeight: 700 }}>Total Distributed</td>
+                    <td className="amount">
+                      ${fmt(distributions.reduce((s, d) => s + d.amount_usd, 0))}
+                    </td>
+                  </tr>
+                </tfoot>
+              </table>
+            </div>
+          )}
+
+          {/* Shipment milestones */}
+          {deal.milestones && deal.milestones.length > 0 && (
+            <div className="receipt-section">
+              <p className="receipt-section-title">Shipment Milestones</p>
+              <div className="milestone-list">
+                {['farm', 'warehouse', 'port', 'importer'].map((step) => {
+                  const m = deal.milestones!.find(x => x.milestone === step);
+                  return (
+                    <div key={step} className="milestone-item">
+                      <div className={`milestone-dot${m ? '' : ' pending'}`} />
+                      <div className="milestone-info">
+                        <p className="milestone-name">
+                          {MILESTONE_LABELS[step] ?? step}
+                        </p>
+                        {m ? (
+                          <>
+                            <p className="milestone-date">
+                              {new Date(m.recorded_at).toLocaleString('en-US', {
+                                dateStyle: 'medium', timeStyle: 'short',
+                              })}
+                            </p>
+                            {m.stellar_tx_id && (
+                              <p className="milestone-tx">
+                                TX: {m.stellar_tx_id}
+                              </p>
+                            )}
+                          </>
+                        ) : (
+                          <p className="milestone-date" style={{ color: '#cbd5e1' }}>
+                            Not yet recorded
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {/* Document references */}
+          {deal.documents && deal.documents.length > 0 && (
+            <div className="receipt-section">
+              <p className="receipt-section-title">Supporting Documents</p>
+              <table className="receipt-table">
+                <thead>
+                  <tr>
+                    <th>Document Type</th>
+                    <th>IPFS Hash</th>
+                    <th>Uploaded</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {deal.documents.map(doc => (
+                    <tr key={doc.id}>
+                      <td style={{ textTransform: 'capitalize', fontWeight: 600 }}>
+                        {doc.doc_type.replace(/_/g, ' ')}
+                      </td>
+                      <td className="mono">{shortHash(doc.ipfs_hash)}</td>
+                      <td>{new Date(doc.created_at).toLocaleDateString('en-US', { dateStyle: 'medium' })}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          {/* Footer */}
+          <div className="receipt-footer">
+            <p className="receipt-footer-note">
+              This receipt is generated by AgriFi. All Stellar transactions are
+              verifiable on the public ledger at stellar.expert.
+            </p>
+            <p className="receipt-footer-generated">Generated {generatedAt}</p>
+          </div>
+
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/deals/[id]/receipt/print.css
+++ b/frontend/src/app/deals/[id]/receipt/print.css
@@ -1,0 +1,432 @@
+/* ── Screen styles ────────────────────────────────────────────────────────── */
+
+.receipt-page {
+  min-height: 100vh;
+  background-color: #f8fafc;
+  font-family: 'Inter', system-ui, sans-serif;
+  color: #0f172a;
+}
+
+.receipt-toolbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1.5rem;
+  background: #ffffff;
+  border-bottom: 1px solid #e2e8f0;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+}
+
+.receipt-toolbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.btn-print {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1.25rem;
+  background-color: #166534;
+  color: #ffffff;
+  font-size: 0.875rem;
+  font-weight: 600;
+  border: none;
+  border-radius: 0.625rem;
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.btn-print:hover {
+  background-color: #14532d;
+}
+
+.btn-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.5rem 1rem;
+  background: transparent;
+  color: #64748b;
+  font-size: 0.875rem;
+  font-weight: 500;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.625rem;
+  cursor: pointer;
+  text-decoration: none;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.btn-back:hover {
+  color: #0f172a;
+  border-color: #94a3b8;
+}
+
+.receipt-wrapper {
+  max-width: 52rem;
+  margin: 2rem auto;
+  padding: 0 1rem 4rem;
+}
+
+.receipt-document {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 1rem;
+  overflow: hidden;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.06);
+}
+
+/* ── Receipt header ───────────────────────────────────────────────────────── */
+
+.receipt-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 2rem 2.5rem 1.5rem;
+  border-bottom: 2px solid #f1f5f9;
+}
+
+.receipt-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  font-size: 1.25rem;
+  font-weight: 900;
+  color: #0f172a;
+  letter-spacing: -0.02em;
+}
+
+.receipt-brand-icon {
+  font-size: 1.5rem;
+}
+
+.receipt-meta {
+  text-align: right;
+}
+
+.receipt-title {
+  font-size: 1.5rem;
+  font-weight: 800;
+  color: #0f172a;
+  letter-spacing: -0.02em;
+  margin: 0 0 0.25rem;
+}
+
+.receipt-subtitle {
+  font-size: 0.75rem;
+  color: #94a3b8;
+  font-family: 'Courier New', monospace;
+}
+
+/* ── Status banner ────────────────────────────────────────────────────────── */
+
+.receipt-status-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.875rem 2.5rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+}
+
+.receipt-status-banner.completed {
+  background-color: #f0fdf4;
+  color: #166534;
+  border-bottom: 1px solid #bbf7d0;
+}
+
+.receipt-status-banner.delivered {
+  background-color: #eff6ff;
+  color: #1d4ed8;
+  border-bottom: 1px solid #bfdbfe;
+}
+
+.receipt-status-banner.funded {
+  background-color: #fefce8;
+  color: #854d0e;
+  border-bottom: 1px solid #fef08a;
+}
+
+.receipt-status-banner.other {
+  background-color: #f8fafc;
+  color: #475569;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+/* ── Sections ─────────────────────────────────────────────────────────────── */
+
+.receipt-section {
+  padding: 1.75rem 2.5rem;
+  border-bottom: 1px solid #f1f5f9;
+}
+
+.receipt-section:last-child {
+  border-bottom: none;
+}
+
+.receipt-section-title {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #94a3b8;
+  margin: 0 0 1rem;
+}
+
+/* ── Deal summary grid ────────────────────────────────────────────────────── */
+
+.receipt-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.875rem;
+}
+
+.receipt-grid-wide {
+  grid-column: span 2;
+}
+
+.receipt-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.receipt-field-label {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #94a3b8;
+}
+
+.receipt-field-value {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.receipt-field-value.mono {
+  font-family: 'Courier New', monospace;
+  font-size: 0.8125rem;
+  word-break: break-all;
+  color: #334155;
+}
+
+.receipt-field-value.large {
+  font-size: 1.25rem;
+  font-weight: 800;
+}
+
+/* ── Payout table ─────────────────────────────────────────────────────────── */
+
+.receipt-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.receipt-table thead tr {
+  border-bottom: 2px solid #f1f5f9;
+}
+
+.receipt-table th {
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #94a3b8;
+}
+
+.receipt-table th:last-child,
+.receipt-table td:last-child {
+  text-align: right;
+}
+
+.receipt-table tbody tr {
+  border-bottom: 1px solid #f8fafc;
+}
+
+.receipt-table tbody tr:last-child {
+  border-bottom: none;
+}
+
+.receipt-table td {
+  padding: 0.75rem;
+  color: #334155;
+  vertical-align: top;
+}
+
+.receipt-table td.mono {
+  font-family: 'Courier New', monospace;
+  font-size: 0.75rem;
+  color: #64748b;
+  word-break: break-all;
+  max-width: 18rem;
+}
+
+.receipt-table td.amount {
+  font-weight: 700;
+  color: #0f172a;
+  white-space: nowrap;
+}
+
+.receipt-table tfoot tr {
+  border-top: 2px solid #e2e8f0;
+  background-color: #f8fafc;
+}
+
+.receipt-table tfoot td {
+  padding: 0.875rem 0.75rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+/* ── Milestones ───────────────────────────────────────────────────────────── */
+
+.milestone-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.milestone-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.875rem;
+}
+
+.milestone-dot {
+  width: 0.625rem;
+  height: 0.625rem;
+  border-radius: 50%;
+  background-color: #166534;
+  margin-top: 0.3125rem;
+  flex-shrink: 0;
+}
+
+.milestone-dot.pending {
+  background-color: #cbd5e1;
+}
+
+.milestone-info {
+  flex: 1;
+}
+
+.milestone-name {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #0f172a;
+  text-transform: capitalize;
+}
+
+.milestone-date {
+  font-size: 0.75rem;
+  color: #94a3b8;
+  margin-top: 0.125rem;
+}
+
+.milestone-tx {
+  font-family: 'Courier New', monospace;
+  font-size: 0.6875rem;
+  color: #64748b;
+  margin-top: 0.25rem;
+  word-break: break-all;
+}
+
+/* ── Footer ───────────────────────────────────────────────────────────────── */
+
+.receipt-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 2.5rem;
+  background-color: #f8fafc;
+  border-top: 1px solid #e2e8f0;
+}
+
+.receipt-footer-note {
+  font-size: 0.75rem;
+  color: #94a3b8;
+}
+
+.receipt-footer-generated {
+  font-size: 0.6875rem;
+  color: #cbd5e1;
+  font-family: 'Courier New', monospace;
+}
+
+/* ── Print media query ────────────────────────────────────────────────────── */
+
+@media print {
+  /* Page setup — A4 portrait */
+  @page {
+    size: A4 portrait;
+    margin: 12mm 14mm;
+  }
+
+  /* Hide everything that isn't the receipt document */
+  .receipt-toolbar,
+  .btn-print,
+  .btn-back,
+  .no-print {
+    display: none !important;
+  }
+
+  /* Reset screen chrome */
+  .receipt-page {
+    background: #ffffff;
+    min-height: unset;
+  }
+
+  .receipt-wrapper {
+    max-width: 100%;
+    margin: 0;
+    padding: 0;
+  }
+
+  .receipt-document {
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+  }
+
+  /* Ensure text is black for ink efficiency */
+  body,
+  .receipt-field-value,
+  .receipt-table td,
+  .receipt-table tfoot td {
+    color: #000000 !important;
+  }
+
+  .receipt-field-label,
+  .receipt-section-title,
+  .receipt-table th {
+    color: #555555 !important;
+  }
+
+  /* Avoid page breaks inside key sections */
+  .receipt-section,
+  .receipt-table tr,
+  .milestone-item {
+    page-break-inside: avoid;
+    break-inside: avoid;
+  }
+
+  /* Force background colours to print */
+  .receipt-status-banner,
+  .receipt-table tfoot tr {
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  /* Links: show the URL inline for printed Stellar TX hashes */
+  a[href]::after {
+    content: none;
+  }
+}


### PR DESCRIPTION
Closes #259 

## Summary

Adds a printable payment receipt page for completed trade deals, giving farmers, traders, and investors a clean A4-formatted document they can print or save as PDF for tax records and bookkeeping. The receipt includes deal details, payment distributions with Stellar transaction hashes, shipment milestones, and supporting document references.

## Problem

Farmers and traders had no way to produce a physical or printable record of their payments. All deal and payment data existed only inside the platform UI, which is unsuitable for tax filings, audits, or bookkeeping. There was no structured view that combined deal info, payout amounts, and on-chain transaction IDs in one place.

## Changes

### `frontend/src/app/deals/[id]/receipt/page.tsx` (new)

A client-side page accessible at `/deals/[id]/receipt`.

**Data loading**
- Fetches deal data via `getDealById` from the existing API client
- Fetches payment distributions from `GET /escrow/distributions/:id` when the deal status is `completed`
- Normalises both `camelCase` and `snake_case` field names from the backend response
- Shows a spinner during loading and a styled error fallback if the deal is not found

**Receipt sections**

Deal Summary — commodity, quantity, token symbol, total value, delivery date, deal status, and the Stellar issuer public key.

Payment Distributions — rendered as a table with four columns: recipient, wallet address (truncated), Stellar TX hash (linked to stellar.expert explorer), and amount in USD. Rows are grouped as:
- 🌾 Farmer — 98% of total deal value
- 💼 Investor 1…N — proportional share per investor
- 🏛 Platform Fee — 2% of total deal value
- Tfoot row showing the total distributed amount

Shipment Milestones — all four steps (Farm Collection, Warehouse Storage, Port Departure, Importer Delivery) listed with recorded timestamps and on-chain TX hashes. Unrecorded steps are shown in a muted pending state.

Supporting Documents — table of uploaded documents with doc type, truncated IPFS hash, and upload date.

Status Banner — colour-coded banner at the top of the document that adapts to the deal's current status (completed, delivered, funded, open, etc.).

**Print Receipt button**
- Sticky toolbar visible on screen, hidden on print
- Calls `window.print()` on click
- Labelled with `aria-label="Print this receipt"` for accessibility

---

### `frontend/src/app/deals/[id]/receipt/print.css` (new)

A dedicated stylesheet imported directly by the receipt page.

**Screen styles** define the full layout: sticky toolbar, A4-width document card, section spacing, table styles, milestone list, and footer.

**`@media print` rules**

| Rule | Effect |
|---|---|
| `@page { size: A4 portrait; margin: 12mm 14mm }` | Sets paper size and margins for A4 printers |
| `.receipt-toolbar, .btn-print, .btn-back, .no-print { display: none }` | Hides all navigation and action elements |
| `background`, `border-radius`, `box-shadow` reset | Removes screen chrome that wastes ink |
| `color: #000000` on body and value elements | Forces black text for ink efficiency |
| `page-break-inside: avoid` on sections, table rows, milestones | Prevents content from splitting across pages |
| `print-color-adjust: exact` on status banner and table footer | Preserves background colours on colour printers |

## Route

/deals/[id]/receipt

This route sits outside the `[locale]` folder intentionally — the receipt is a utility page that does not require i18n and should be directly linkable from deal detail pages or email notifications.

## Files Changed

| File | Change |
|---|---|
| `frontend/src/app/deals/[id]/receipt/page.tsx` | New receipt page component |
| `frontend/src/app/deals/[id]/receipt/print.css` | New print stylesheet with `@media print` rules |
