### PR TITLE
fix: replace inline role checks with RolesGuard in TradeDealsController

### DIFF
--- a/backend/src/trade-deals/trade-deals.controller.ts
+++ b/backend/src/trade-deals/trade-deals.controller.ts
@@ -7,7 +7,6 @@ import {
   Body,
   UseGuards,
   Request,
-  ForbiddenException,
   HttpCode,
 } from '@nestjs/common';
 import {
@@ -23,6 +22,7 @@ import { TradeDealsService } from './trade-deals.service';
 import { TradeDeal } from './entities/trade-deal.entity';
 import { User } from '../auth/entities/user.entity';
 import { KycGuard } from '../auth/kyc.guard';
+import { Roles, RolesGuard } from '../auth/roles.guard';
 import { OptionalJwtGuard } from '../auth/optional-jwt.guard';
 import { CreateTradeDealDto } from './dto/create-trade-deal.dto';
 
@@ -38,7 +38,8 @@ export class TradeDealsController {
   constructor(private readonly tradeDealsService: TradeDealsService) {}
 
   @Post()
-  @UseGuards(AuthGuard('jwt'), KycGuard)
+  @UseGuards(AuthGuard('jwt'), RolesGuard, KycGuard)
+  @Roles('trader', 'farmer')
   @ApiBearerAuth('jwt')
   @ApiOperation({
     summary: 'Create a draft trade deal (trader or farmer, KYC required)',
@@ -51,12 +52,6 @@ export class TradeDealsController {
     @Request() req: AuthRequest,
     @Body() dto: CreateTradeDealDto,
   ): Promise<TradeDeal> {
-    if (req.user.role !== 'trader' && req.user.role !== 'farmer') {
-      throw new ForbiddenException({
-        code: 'ROLE_REQUIRED',
-        message: 'Only traders or farmers can create trade deals.',
-      });
-    }
     // Farmers self-list: they are both the farmer and the acting trader
     if (req.user.role === 'farmer') {
       dto.farmer_id = req.user.id;
@@ -67,7 +62,8 @@ export class TradeDealsController {
 
   @Post(':id/publish')
   @HttpCode(202)
-  @UseGuards(AuthGuard('jwt'), KycGuard)
+  @UseGuards(AuthGuard('jwt'), RolesGuard, KycGuard)
+  @Roles('trader')
   @ApiBearerAuth('jwt')
   @ApiOperation({
     summary: 'Publish a draft trade deal (async token issuance)',
@@ -88,13 +84,6 @@ export class TradeDealsController {
     @Param('id') id: string,
     @Request() req: AuthRequest,
   ): Promise<TradeDeal> {
-    if (req.user.role !== 'trader') {
-      throw new ForbiddenException({
-        code: 'ROLE_REQUIRED',
-        message: 'Only traders can publish trade deals.',
-      });
-    }
-
     return this.tradeDealsService.publishDeal(id, req.user.id);
   }
 
@@ -133,7 +122,8 @@ export class TradeDealsController {
   }
 
   @Post(':id/cancel')
-  @UseGuards(AuthGuard('jwt'), KycGuard)
+  @UseGuards(AuthGuard('jwt'), RolesGuard, KycGuard)
+  @Roles('trader')
   @ApiBearerAuth('jwt')
   @ApiOperation({
     summary:
@@ -147,13 +137,6 @@ export class TradeDealsController {
     @Param('id') id: string,
     @Request() req: AuthRequest,
   ): Promise<TradeDeal> {
-    if (req.user.role !== 'trader') {
-      throw new ForbiddenException({
-        code: 'ROLE_REQUIRED',
-        message: 'Only traders can cancel trade deals.',
-      });
-    }
-
     return this.tradeDealsService.cancelDeal(id, req.user.id);
   }
 }


### PR DESCRIPTION
Closes #223 

## Summary

Three endpoints in `TradeDealsController` were performing role authorization via inline `if` checks inside the handler body instead of using the `RolesGuard` at the guard layer. This was inconsistent with the rest of the codebase (e.g., `AdminController`) and introduced a subtle but critical security ordering bug.

---

## Problem

### Affected Endpoints

- `POST /trade-deals`
- `POST /trade-deals/:id/publish`
- `POST /trade-deals/:id/cancel`

### Inline Role Check Pattern

Each of the affected endpoints contained logic like this inside the handler body:

```typescript
if (req.user.role !== 'trader') {
  throw new ForbiddenException({
    code: 'ROLE_REQUIRED',
    message: 'Only traders can publish trade deals.',
  });
}
```

This approach has two concrete problems:

---

### 1. Incorrect Guard Execution Order

The guard chain on these endpoints was:

```
AuthGuard → KycGuard → handler (inline role check)
```

Because `KycGuard` ran before the role check, a user with the wrong role (e.g., an investor) would receive a `KYC_REQUIRED` error instead of a `ROLE_REQUIRED` error — even if their KYC was the least of the problems. The role check was never reached if KYC failed first.

The correct order should be:

```
AuthGuard → RolesGuard → KycGuard → handler
```

Role must be validated before KYC, since KYC is a secondary requirement that only applies to users who already have the correct role for the action.

---

### 2. Inconsistency with the Rest of the Codebase

`AdminController` correctly uses the declarative `@Roles()` decorator combined with `RolesGuard` at the guard layer:

```typescript
@UseGuards(AuthGuard('jwt'), RolesGuard)
@Roles('admin')
```

The inline approach in `TradeDealsController` diverged from this established pattern, making authorization logic harder to audit, test, and reason about consistently across the codebase.

---

## Fix

Replaced all inline role checks with the `@Roles()` decorator and inserted `RolesGuard` into the `@UseGuards()` chain between `AuthGuard` and `KycGuard`.

### `POST /trade-deals`

**Before:**
```typescript
@Post()
@UseGuards(AuthGuard('jwt'), KycGuard)
async createDeal(@Request() req: AuthRequest, @Body() dto: CreateTradeDealDto) {
  if (req.user.role !== 'trader' && req.user.role !== 'farmer') {
    throw new ForbiddenException({
      code: 'ROLE_REQUIRED',
      message: 'Only traders or farmers can create trade deals.',
    });
  }
  // ...
}
```

**After:**
```typescript
@Post()
@UseGuards(AuthGuard('jwt'), RolesGuard, KycGuard)
@Roles('trader', 'farmer')
async createDeal(@Request() req: AuthRequest, @Body() dto: CreateTradeDealDto) {
  // ...
}
```

---

### `POST /trade-deals/:id/publish`

**Before:**
```typescript
@Post(':id/publish')
@UseGuards(AuthGuard('jwt'), KycGuard)
async publishDeal(@Param('id') id: string, @Request() req: AuthRequest) {
  if (req.user.role !== 'trader') {
    throw new ForbiddenException({
      code: 'ROLE_REQUIRED',
      message: 'Only traders can publish trade deals.',
    });
  }
  return this.tradeDealsService.publishDeal(id, req.user.id);
}
```

**After:**
```typescript
@Post(':id/publish')
@UseGuards(AuthGuard('jwt'), RolesGuard, KycGuard)
@Roles('trader')
async publishDeal(@Param('id') id: string, @Request() req: AuthRequest) {
  return this.tradeDealsService.publishDeal(id, req.user.id);
}
```

---

### `POST /trade-deals/:id/cancel`

**Before:**
```typescript
@Post(':id/cancel')
@UseGuards(AuthGuard('jwt'), KycGuard)
async cancelDeal(@Param('id') id: string, @Request() req: AuthRequest) {
  if (req.user.role !== 'trader') {
    throw new ForbiddenException({
      code: 'ROLE_REQUIRED',
      message: 'Only traders can cancel trade deals.',
    });
  }
  return this.tradeDealsService.cancelDeal(id, req.user.id);
}
```

**After:**
```typescript
@Post(':id/cancel')
@UseGuards(AuthGuard('jwt'), RolesGuard, KycGuard)
@Roles('trader')
async cancelDeal(@Param('id') id: string, @Request() req: AuthRequest) {
  return this.tradeDealsService.cancelDeal(id, req.user.id);
}
```