### PR TITLE
feat: configure RabbitMQ Prometheus plugin with alert thresholds

### DIFF
--- a/devops/rabbitmq/enabled_plugins
+++ b/devops/rabbitmq/enabled_plugins
@@ -1,0 +1,1 @@
+[rabbitmq_management,rabbitmq_prometheus].

--- a/devops/rabbitmq/rabbitmq.conf
+++ b/devops/rabbitmq/rabbitmq.conf
@@ -1,0 +1,29 @@
+# RabbitMQ configuration with Prometheus metrics plugin
+
+# Enable Prometheus metrics endpoint
+prometheus.tcp.port = 15692
+prometheus.path = /metrics
+
+# Prometheus plugin settings
+prometheus.return_per_object_metrics = true
+
+# Alert thresholds — consumers are notified via alertmanager rules (see prometheus/alerts/)
+# Queue length warning threshold (messages)
+prometheus.queue_length_warning_threshold = 1000
+# Queue length critical threshold (messages)
+prometheus.queue_length_critical_threshold = 5000
+
+# General queue settings
+default_vhost = /
+default_user = guest
+default_pass = guest
+
+# Management plugin
+management.tcp.port = 15672
+management.tcp.ip = 0.0.0.0
+
+# Logging
+log.console = true
+log.console.level = info
+log.file = /var/log/rabbitmq/rabbit.log
+log.file.level = info


### PR DESCRIPTION
Closes #520

Adds `devops/rabbitmq/rabbitmq.conf` enabling `rabbitmq_prometheus` on port 15692 with queue length warning (1000) and critical (5000) thresholds, and `devops/rabbitmq/enabled_plugins` to activate the plugin alongside management.