### PR TITLE
Fix container healthchecks and k8s resources

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm ci
+
+COPY . .
+
+RUN npm run build
+
+EXPOSE 3000
+
+CMD ["npm", "run", "start:prod"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,11 +13,6 @@ RUN npm run build
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
-  CMD wget -qO- http://127.0.0.1:3000/health || exit 1
+  CMD ["/bin/sh", "-c", "wget -q --spider http://127.0.0.1:3000/health || exit 1"]
 
 CMD ["npm", "run", "start:prod"]
-EOF && git add backend/Dockerfile && GIT_AUTHOR_NAME='fortezzalaboratory' GIT_AUTHOR_EMAIL='fortezzalabs@gmail.com' GIT_COMMITTER_NAME='fortezzalaboratory' GIT_COMMITTER_EMAIL='fortezzalabs@gmail.com' git commit --trailer "Co-authored-by: Cursor <cursoragent@cursor.com>" -F - <<'MSG'
-feat(devops): add backend container health probe
-
-Adds Docker HEALTHCHECK for backend service to satisfy #521 runtime validation requirement.
-MSG

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,4 +12,12 @@ RUN npm run build
 
 EXPOSE 3000
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:3000/health || exit 1
+
 CMD ["npm", "run", "start:prod"]
+EOF && git add backend/Dockerfile && GIT_AUTHOR_NAME='fortezzalaboratory' GIT_AUTHOR_EMAIL='fortezzalabs@gmail.com' GIT_COMMITTER_NAME='fortezzalaboratory' GIT_COMMITTER_EMAIL='fortezzalabs@gmail.com' git commit --trailer "Co-authored-by: Cursor <cursoragent@cursor.com>" -F - <<'MSG'
+feat(devops): add backend container health probe
+
+Adds Docker HEALTHCHECK for backend service to satisfy #521 runtime validation requirement.
+MSG

--- a/backend/k8s/deployment.yaml
+++ b/backend/k8s/deployment.yaml
@@ -19,3 +19,7 @@ spec:
           image: agri-fi/backend:latest
           ports:
             - containerPort: 3000
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "256Mi"

--- a/backend/k8s/deployment.yaml
+++ b/backend/k8s/deployment.yaml
@@ -23,3 +23,6 @@ spec:
             requests:
               cpu: "250m"
               memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"

--- a/backend/k8s/deployment.yaml
+++ b/backend/k8s/deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agri-fi-backend
+  labels:
+    app: agri-fi-backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: agri-fi-backend
+  template:
+    metadata:
+      labels:
+        app: agri-fi-backend
+    spec:
+      containers:
+        - name: backend
+          image: agri-fi/backend:latest
+          ports:
+            - containerPort: 3000

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -13,6 +13,6 @@ RUN npm run build
 EXPOSE 3001
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
-  CMD wget -qO- http://127.0.0.1:3001 || exit 1
+  CMD ["/bin/sh", "-c", "wget -q --spider http://127.0.0.1:3001 || exit 1"]
 
 CMD ["npm", "run", "start"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm ci
+
+COPY . .
+
+RUN npm run build
+
+EXPOSE 3001
+
+CMD ["npm", "run", "start"]
+EOF && git add frontend/Dockerfile && GIT_AUTHOR_NAME='fortezzalaboratory' GIT_AUTHOR_EMAIL='fortezzalabs@gmail.com' GIT_COMMITTER_NAME='fortezzalaboratory' GIT_COMMITTER_EMAIL='fortezzalabs@gmail.com' git commit --trailer "Co-authored-by: Cursor <cursoragent@cursor.com>" -m "chore(devops): scaffold frontend container image" -m "Adds baseline frontend Dockerfile to prepare health validation work for #521."

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -12,5 +12,7 @@ RUN npm run build
 
 EXPOSE 3001
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:3001 || exit 1
+
 CMD ["npm", "run", "start"]
-EOF && git add frontend/Dockerfile && GIT_AUTHOR_NAME='fortezzalaboratory' GIT_AUTHOR_EMAIL='fortezzalabs@gmail.com' GIT_COMMITTER_NAME='fortezzalaboratory' GIT_COMMITTER_EMAIL='fortezzalabs@gmail.com' git commit --trailer "Co-authored-by: Cursor <cursoragent@cursor.com>" -m "chore(devops): scaffold frontend container image" -m "Adds baseline frontend Dockerfile to prepare health validation work for #521."

--- a/frontend/k8s/deployment.yaml
+++ b/frontend/k8s/deployment.yaml
@@ -19,3 +19,7 @@ spec:
           image: agri-fi/frontend:latest
           ports:
             - containerPort: 3001
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "256Mi"

--- a/frontend/k8s/deployment.yaml
+++ b/frontend/k8s/deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agri-fi-frontend
+  labels:
+    app: agri-fi-frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: agri-fi-frontend
+  template:
+    metadata:
+      labels:
+        app: agri-fi-frontend
+    spec:
+      containers:
+        - name: frontend
+          image: agri-fi/frontend:latest
+          ports:
+            - containerPort: 3001

--- a/frontend/k8s/deployment.yaml
+++ b/frontend/k8s/deployment.yaml
@@ -23,3 +23,6 @@ spec:
             requests:
               cpu: "200m"
               memory: "256Mi"
+            limits:
+              cpu: "400m"
+              memory: "512Mi"


### PR DESCRIPTION
## Summary
- add `backend/Dockerfile` and `frontend/Dockerfile` with Docker `HEALTHCHECK` directives to validate service liveness inside containers
- add `backend/k8s/deployment.yaml` and `frontend/k8s/deployment.yaml` with CPU/memory requests and limits for both workloads
- keep changes split into small incremental commits to isolate each DevOps requirement

## Verification
- confirmed Dockerfiles include healthcheck commands that fail when endpoints are unreachable
- confirmed both deployment manifests define `resources.requests` and `resources.limits` for CPU and memory
- verified recent commit metadata uses `fortezzalaboratory <fortezzalabs@gmail.com>` for author and committer

Closes #521
Closes #517

Made with [Cursor](https://cursor.com)