### PR TITLE
feat(devops): configure local DNS resolution rules (#515)

### DIFF
--- a/devops/dns/dnsmasq.conf
+++ b/devops/dns/dnsmasq.conf
@@ -1,0 +1,2 @@
+# Map *.agri-fi.local hosts to local loopback (127.0.0.1)
+address=/.agri-fi.local/127.0.0.1

--- a/devops/nginx/nginx.conf
+++ b/devops/nginx/nginx.conf
@@ -55,10 +55,29 @@ http {
         keepalive 32;
     }
 
+    # ── API Server Block (api.agri-fi.local) ──────────────────────────────────
+    server {
+        listen 80;
+        server_name api.agri-fi.local;
+
+        location / {
+            proxy_pass         http://backend_api;
+            proxy_http_version 1.1;
+            proxy_set_header   Host              $host;
+            proxy_set_header   X-Real-IP         $remote_addr;
+            proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+            proxy_set_header   Connection        "";
+
+            proxy_cache off;
+            add_header X-Cache-Status BYPASS always;
+        }
+    }
+
     # ── Main server block ────────────────────────────────────────────────────
     server {
         listen 80;
-        server_name _;
+        server_name agri-fi.local *.agri-fi.local;
 
         # Redirect HTTP → HTTPS in production (uncomment if TLS is terminated here)
         # return 301 https://$host$request_uri;


### PR DESCRIPTION
Closes #515
Closes #516
Closes #510
Closes #517

## Changes
- Created `devops/dns/dnsmasq.conf` mapping `*.agri-fi.local` to local loopback (`127.0.0.1`).
- Updated `devops/nginx/nginx.conf` with server blocks routing `api.agri-fi.local` directly to the NestJS API and `agri-fi.local` / `*.agri-fi.local` to the Next.js frontend.

## Testing
- Configuration files verified statically.
