### PR TITLE
feat: add kubernetes scaling and efk manifests

### DIFF
--- a/backend/k8s/deployment.yaml
+++ b/backend/k8s/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: agri-fi-backend
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: agri-fi-backend
@@ -17,8 +17,28 @@ spec:
       containers:
         - name: backend
           image: agri-fi/backend:latest
+          imagePullPolicy: IfNotPresent
           ports:
-            - containerPort: 3000
+            - name: http
+              containerPort: 3001
+          envFrom:
+            - configMapRef:
+                name: agri-fi-backend-config
+            - secretRef:
+                name: agri-fi-backend-secrets
+                optional: true
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 20
           resources:
             requests:
               cpu: "250m"
@@ -26,3 +46,22 @@ spec:
             limits:
               cpu: "500m"
               memory: "512Mi"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agri-fi-backend-config
+  labels:
+    app: agri-fi-backend
+data:
+  NODE_ENV: "production"
+  PORT: "3001"
+  LOG_LEVEL: "info"
+  LOG_PRETTY: "false"
+  DATABASE_HOST: "postgres"
+  DATABASE_PORT: "5432"
+  DATABASE_NAME: "agric_onchain"
+  RABBITMQ_URL: "amqp://rabbitmq:5672"
+  STELLAR_NETWORK: "testnet"
+  STELLAR_HORIZON_URL: "https://horizon-testnet.stellar.org"
+  ALLOWED_ORIGINS: "http://agri-fi-frontend"

--- a/backend/k8s/service.yaml
+++ b/backend/k8s/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: agri-fi-backend
+  labels:
+    app: agri-fi-backend
+spec:
+  type: ClusterIP
+  selector:
+    app: agri-fi-backend
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP

--- a/devops/efk/docker-compose.yml
+++ b/devops/efk/docker-compose.yml
@@ -1,0 +1,36 @@
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.15.3
+    environment:
+      discovery.type: single-node
+      xpack.security.enabled: "false"
+      ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+    ports:
+      - "9200:9200"
+    volumes:
+      - elasticsearch-data:/usr/share/elasticsearch/data
+
+  fluentd:
+    image: fluent/fluentd-kubernetes-daemonset:v1.16-debian-elasticsearch8-1
+    depends_on:
+      - elasticsearch
+    volumes:
+      - ./fluentd.conf:/fluentd/etc/fluent.conf:ro
+      - /var/log:/var/log:ro
+      - fluentd-buffer:/fluentd/log
+    ports:
+      - "24224:24224"
+      - "24224:24224/udp"
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:8.15.3
+    depends_on:
+      - elasticsearch
+    environment:
+      ELASTICSEARCH_HOSTS: "http://elasticsearch:9200"
+    ports:
+      - "5601:5601"
+
+volumes:
+  elasticsearch-data:
+  fluentd-buffer:

--- a/devops/efk/fluentd.conf
+++ b/devops/efk/fluentd.conf
@@ -1,0 +1,44 @@
+<source>
+  @type tail
+  path /var/log/containers/*.log
+  pos_file /fluentd/log/containers.log.pos
+  tag kubernetes.*
+  read_from_head true
+  <parse>
+    @type json
+    time_key time
+    time_type string
+    time_format %Y-%m-%dT%H:%M:%S.%NZ
+    keep_time_key true
+  </parse>
+</source>
+
+<filter kubernetes.**>
+  @type parser
+  key_name log
+  reserve_data true
+  emit_invalid_record_to_error false
+  <parse>
+    @type json
+  </parse>
+</filter>
+
+<match kubernetes.**>
+  @type elasticsearch
+  host elasticsearch
+  port 9200
+  scheme http
+  logstash_format true
+  logstash_prefix agri-fi
+  include_tag_key true
+  tag_key fluentd_tag
+  reconnect_on_error true
+  reload_on_failure true
+  request_timeout 30s
+  <buffer>
+    @type file
+    path /fluentd/log/elasticsearch
+    flush_interval 5s
+    retry_forever true
+  </buffer>
+</match>

--- a/devops/k8s/hpa.yaml
+++ b/devops/k8s/hpa.yaml
@@ -1,0 +1,41 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: agri-fi-backend
+  labels:
+    app: agri-fi-backend
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: agri-fi-backend
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: agri-fi-frontend
+  labels:
+    app: agri-fi-frontend
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: agri-fi-frontend
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80

--- a/frontend/k8s/deployment.yaml
+++ b/frontend/k8s/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: agri-fi-frontend
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: agri-fi-frontend
@@ -17,8 +17,25 @@ spec:
       containers:
         - name: frontend
           image: agri-fi/frontend:latest
+          imagePullPolicy: IfNotPresent
           ports:
-            - containerPort: 3001
+            - name: http
+              containerPort: 3001
+          envFrom:
+            - configMapRef:
+                name: agri-fi-frontend-config
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 20
           resources:
             requests:
               cpu: "200m"
@@ -26,3 +43,14 @@ spec:
             limits:
               cpu: "400m"
               memory: "512Mi"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agri-fi-frontend-config
+  labels:
+    app: agri-fi-frontend
+data:
+  NODE_ENV: "production"
+  NEXT_PUBLIC_API_URL: "http://agri-fi-backend"
+  BACKEND_URL: "http://agri-fi-backend"

--- a/frontend/k8s/service.yaml
+++ b/frontend/k8s/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: agri-fi-frontend
+  labels:
+    app: agri-fi-frontend
+spec:
+  type: ClusterIP
+  selector:
+    app: agri-fi-frontend
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP


### PR DESCRIPTION
## Description
Adds Kubernetes deployment/service coverage for the backend and frontend, shared pod autoscaling policies, and an EFK stack configuration for centralized JSON log aggregation.

Closes #509
Closes #497
Closes #496
Closes #495

## Changes proposed

### What were you told to do?
Create one PR that closes the four DevOps issues for pod autoscaling, frontend Kubernetes manifests, backend Kubernetes manifests, and EFK log aggregation.

### What did I do?
#### Kubernetes Deployments and Services
- Updated backend and frontend deployments to run two replicas by default.
- Added named HTTP ports, readiness probes, liveness probes, and image pull policy settings.
- Added backend and frontend ClusterIP services with port 80 mapped to each app container HTTP port.

#### Configuration References
- Added backend ConfigMap settings and wired the deployment through `envFrom` ConfigMap and optional Secret references.
- Added frontend ConfigMap settings and wired the deployment through `envFrom`.

#### Autoscaling
- Added `devops/k8s/hpa.yaml` with HorizontalPodAutoscaler resources for backend and frontend deployments.
- Set CPU utilization target to 80% with min 2 and max 10 replicas.

#### EFK Logging
- Added Fluentd configuration that tails container logs, parses JSON log payloads, and forwards them to Elasticsearch using `agri-fi` logstash index prefixes.
- Added Docker Compose services for Elasticsearch, Fluentd, and Kibana.

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
- Synced local `main` with `upstream/main` before creating the branch.
- `docker compose -f devops/efk/docker-compose.yml config` passed.
- `git diff --check` passed.
- Attempted `kubectl apply --dry-run=client` for the Kubernetes manifests, but local kubectl tried to contact `localhost:8080` and failed because no cluster context is available in this environment.