### PR TITLE
test: regression hooks, offline cache, security headers, and audit log tests (#485–#488)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -68,6 +68,7 @@
     "@types/passport-jwt": "^3.0.0",
     "@types/passport-local": "^1.0.0",
     "@types/uuid": "^9.0.0",
+    "@types/supertest": "^6.0.0",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
     "eslint": "^8.57.0",
@@ -75,6 +76,7 @@
     "eslint-plugin-prettier": "^5.0.0",
     "fast-check": "^3.15.0",
     "jest": "^29.7.0",
+    "supertest": "^7.0.0",
     "prettier": "^3.0.0",
     "ts-jest": "^29.4.9",
     "ts-node": "^10.9.0",
@@ -87,15 +89,19 @@
       "json",
       "ts"
     ],
-    "rootDir": "src",
+    "rootDir": ".",
+    "roots": [
+      "<rootDir>/src",
+      "<rootDir>/test"
+    ],
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },
     "collectCoverageFrom": [
-      "**/*.(t|j)s"
+      "src/**/*.(t|j)s"
     ],
-    "coverageDirectory": "../coverage",
+    "coverageDirectory": "./coverage",
     "testEnvironment": "node"
   }
 }

--- a/backend/src/common/middleware/security-headers.middleware.ts
+++ b/backend/src/common/middleware/security-headers.middleware.ts
@@ -1,0 +1,8 @@
+export function applySecurityHeaders(req: any, res: any, next: () => void): void {
+  res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
+  res.setHeader('Content-Security-Policy', "default-src 'self'");
+  res.setHeader('X-Content-Type-Options', 'nosniff');
+  res.setHeader('X-Frame-Options', 'DENY');
+  res.setHeader('Referrer-Policy', 'no-referrer');
+  next();
+}

--- a/backend/src/database/entities/audit-log.entity.ts
+++ b/backend/src/database/entities/audit-log.entity.ts
@@ -1,0 +1,22 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from 'typeorm';
+
+@Entity('audit_logs')
+export class AuditLog {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'entity_name' })
+  entityName: string;
+
+  @Column({ name: 'entity_id', nullable: true })
+  entityId: string | null;
+
+  @Column({ length: 20 })
+  action: string;
+
+  @Column({ type: 'text', nullable: true })
+  changes: string | null;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+}

--- a/backend/src/database/subscribers/audit.subscriber.spec.ts
+++ b/backend/src/database/subscribers/audit.subscriber.spec.ts
@@ -1,0 +1,130 @@
+import { AuditSubscriber } from './audit.subscriber';
+import { AuditLog } from '../entities/audit-log.entity';
+import { TradeDeal } from '../../trade-deals/entities/trade-deal.entity';
+import { InsertEvent, UpdateEvent } from 'typeorm';
+
+describe('AuditSubscriber', () => {
+  let subscriber: AuditSubscriber;
+  let mockManager: { save: jest.Mock };
+  let mockDataSource: { subscribers: AuditSubscriber[] };
+
+  const baseDeal: Partial<TradeDeal> = {
+    id: 'deal-uuid',
+    commodity: 'Maize',
+    status: 'draft',
+    totalValue: 5000,
+    tokenCount: 50,
+    tokenSymbol: 'MZE-001',
+  };
+
+  beforeEach(() => {
+    mockManager = { save: jest.fn().mockResolvedValue({}) };
+    mockDataSource = { subscribers: [] };
+    subscriber = new AuditSubscriber(mockDataSource as any);
+  });
+
+  it('registers itself with the DataSource subscribers list on construction', () => {
+    expect(mockDataSource.subscribers).toContain(subscriber);
+  });
+
+  it('listens to the TradeDeal entity', () => {
+    expect(subscriber.listenTo()).toBe(TradeDeal);
+  });
+
+  describe('afterInsert', () => {
+    it('writes an AuditLog INSERT record when a TradeDeal is saved', async () => {
+      const event = {
+        entity: baseDeal,
+        manager: mockManager,
+      } as unknown as InsertEvent<TradeDeal>;
+
+      await subscriber.afterInsert(event);
+
+      expect(mockManager.save).toHaveBeenCalledTimes(1);
+      expect(mockManager.save).toHaveBeenCalledWith(
+        AuditLog,
+        expect.objectContaining({
+          entityName: 'TradeDeal',
+          entityId: 'deal-uuid',
+          action: 'INSERT',
+        }),
+      );
+    });
+
+    it('serialises the inserted entity as JSON in the changes field', async () => {
+      const event = {
+        entity: baseDeal,
+        manager: mockManager,
+      } as unknown as InsertEvent<TradeDeal>;
+
+      await subscriber.afterInsert(event);
+
+      const [, auditPayload] = mockManager.save.mock.calls[0];
+      const parsed = JSON.parse(auditPayload.changes);
+      expect(parsed).toMatchObject({ id: 'deal-uuid', commodity: 'Maize' });
+    });
+
+    it('stores a null entityId when the inserted entity has no id', async () => {
+      const event = {
+        entity: {},
+        manager: mockManager,
+      } as unknown as InsertEvent<TradeDeal>;
+
+      await subscriber.afterInsert(event);
+
+      const [, auditPayload] = mockManager.save.mock.calls[0];
+      expect(auditPayload.entityId).toBeNull();
+    });
+  });
+
+  describe('afterUpdate', () => {
+    it('writes an AuditLog UPDATE record when a TradeDeal is modified', async () => {
+      const event = {
+        entity: { ...baseDeal, status: 'open' },
+        manager: mockManager,
+        updatedColumns: [{ propertyName: 'status' }],
+      } as unknown as UpdateEvent<TradeDeal>;
+
+      await subscriber.afterUpdate(event);
+
+      expect(mockManager.save).toHaveBeenCalledTimes(1);
+      expect(mockManager.save).toHaveBeenCalledWith(
+        AuditLog,
+        expect.objectContaining({
+          entityName: 'TradeDeal',
+          entityId: 'deal-uuid',
+          action: 'UPDATE',
+        }),
+      );
+    });
+
+    it('records the names of all updated columns in the changes field', async () => {
+      const event = {
+        entity: baseDeal,
+        manager: mockManager,
+        updatedColumns: [
+          { propertyName: 'status' },
+          { propertyName: 'totalInvested' },
+        ],
+      } as unknown as UpdateEvent<TradeDeal>;
+
+      await subscriber.afterUpdate(event);
+
+      const [, auditPayload] = mockManager.save.mock.calls[0];
+      expect(JSON.parse(auditPayload.changes)).toEqual(['status', 'totalInvested']);
+    });
+
+    it('stores an empty changes array when no columns are listed', async () => {
+      const event = {
+        entity: baseDeal,
+        manager: mockManager,
+        updatedColumns: [],
+      } as unknown as UpdateEvent<TradeDeal>;
+
+      await subscriber.afterUpdate(event);
+
+      const [, auditPayload] = mockManager.save.mock.calls[0];
+      expect(JSON.parse(auditPayload.changes)).toEqual([]);
+    });
+  });
+});

--- a/backend/src/database/subscribers/audit.subscriber.ts
+++ b/backend/src/database/subscribers/audit.subscriber.ts
@@ -1,0 +1,43 @@
+import {
+  DataSource,
+  EntitySubscriberInterface,
+  EventSubscriber,
+  InsertEvent,
+  UpdateEvent,
+} from 'typeorm';
+import { Injectable } from '@nestjs/common';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { TradeDeal } from '../../trade-deals/entities/trade-deal.entity';
+import { AuditLog } from '../entities/audit-log.entity';
+
+@Injectable()
+@EventSubscriber()
+export class AuditSubscriber implements EntitySubscriberInterface<TradeDeal> {
+  constructor(@InjectDataSource() private readonly dataSource: DataSource) {
+    dataSource.subscribers.push(this);
+  }
+
+  listenTo() {
+    return TradeDeal;
+  }
+
+  async afterInsert(event: InsertEvent<TradeDeal>): Promise<void> {
+    await event.manager.save(AuditLog, {
+      entityName: 'TradeDeal',
+      entityId: event.entity?.id ?? null,
+      action: 'INSERT',
+      changes: JSON.stringify(event.entity),
+    });
+  }
+
+  async afterUpdate(event: UpdateEvent<TradeDeal>): Promise<void> {
+    await event.manager.save(AuditLog, {
+      entityName: 'TradeDeal',
+      entityId: event.entity?.id ?? null,
+      action: 'UPDATE',
+      changes: JSON.stringify(
+        event.updatedColumns?.map((col) => col.propertyName) ?? [],
+      ),
+    });
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -3,9 +3,12 @@ import { NestFactory } from '@nestjs/core';
 import { ValidationPipe, BadRequestException } from '@nestjs/common';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AppModule } from './app.module';
+import { applySecurityHeaders } from './common/middleware/security-headers.middleware';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  app.use(applySecurityHeaders);
 
   app.useGlobalPipes(
     new ValidationPipe({

--- a/backend/test/security-headers.e2e-spec.ts
+++ b/backend/test/security-headers.e2e-spec.ts
@@ -1,0 +1,61 @@
+import { INestApplication, Controller, Get, Module } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import * as request from 'supertest';
+import { applySecurityHeaders } from '../src/common/middleware/security-headers.middleware';
+
+@Controller()
+class RootController {
+  @Get()
+  root() {
+    return { status: 'ok' };
+  }
+}
+
+@Module({ controllers: [RootController] })
+class TestAppModule {}
+
+describe('Security Headers (E2E)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [TestAppModule],
+    }).compile();
+
+    app = module.createNestApplication();
+    app.use(applySecurityHeaders);
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('sets Strict-Transport-Security (HSTS) header', async () => {
+    const response = await request(app.getHttpServer()).get('/');
+    expect(response.headers['strict-transport-security']).toBeDefined();
+    expect(response.headers['strict-transport-security']).toContain('max-age=31536000');
+    expect(response.headers['strict-transport-security']).toContain('includeSubDomains');
+  });
+
+  it('sets Content-Security-Policy (CSP) header', async () => {
+    const response = await request(app.getHttpServer()).get('/');
+    expect(response.headers['content-security-policy']).toBeDefined();
+    expect(response.headers['content-security-policy']).toContain("default-src 'self'");
+  });
+
+  it('sets X-Content-Type-Options header to nosniff', async () => {
+    const response = await request(app.getHttpServer()).get('/');
+    expect(response.headers['x-content-type-options']).toBe('nosniff');
+  });
+
+  it('sets X-Frame-Options header to DENY', async () => {
+    const response = await request(app.getHttpServer()).get('/');
+    expect(response.headers['x-frame-options']).toBe('DENY');
+  });
+
+  it('sets Referrer-Policy header', async () => {
+    const response = await request(app.getHttpServer()).get('/');
+    expect(response.headers['referrer-policy']).toBe('no-referrer');
+  });
+});

--- a/frontend/.husky/pre-commit
+++ b/frontend/.husky/pre-commit
@@ -1,0 +1,1 @@
+npm test -- --watchAll=false --passWithNoTests

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest"
+    "test": "jest",
+    "prepare": "husky"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.6.0",
@@ -39,6 +40,7 @@
     "autoprefixer": "^10.4.0",
     "eslint": "^8.57.1",
     "eslint-config-next": "14.2.3",
+    "husky": "^9.0.0",
     "jest": "^30.3.0",
     "jest-environment-jsdom": "^30.3.0",
     "postcss": "^8.4.0",

--- a/frontend/src/hooks/useDashboardData.spec.ts
+++ b/frontend/src/hooks/useDashboardData.spec.ts
@@ -1,0 +1,136 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useDashboardData } from './useDashboardData';
+import { apiClient } from '../lib/api';
+
+jest.mock('../lib/api', () => ({
+  apiClient: {
+    refreshCurrentUser: jest.fn(),
+    getInvestorInvestments: jest.fn(),
+  },
+}));
+
+const mockRefreshUser = apiClient.refreshCurrentUser as jest.Mock;
+const mockGetInvestments = apiClient.getInvestorInvestments as jest.Mock;
+
+const CACHE_KEY = 'dashboard_data';
+
+const mockUser = {
+  id: 'user-1',
+  email: 'investor@example.com',
+  role: 'investor' as const,
+  name: 'Test Investor',
+};
+
+const mockInvestments = [
+  {
+    id: 'inv-1',
+    trade_deal_id: 'deal-1',
+    investor_id: 'user-1',
+    token_amount: 10,
+    amount_usd: 1000,
+    amount_invested: 1000,
+    token_holdings: 10,
+    status: 'confirmed' as const,
+    created_at: '2024-01-01T00:00:00Z',
+    expected_return_usd: 1150,
+    actual_return_usd: null,
+    return_percentage: null,
+    deal: {
+      id: 'deal-1',
+      commodity: 'maize',
+      quantity: 1000,
+      quantity_unit: 'kg',
+      total_value: 10000,
+      funded_amount: 5000,
+      total_invested: 5000,
+      token_count: 100,
+      tokens_remaining: 50,
+      token_symbol: 'MZE',
+      issuer_public_key: null,
+      status: 'open' as const,
+      delivery_date: '2025-06-01',
+      created_at: '2024-01-01T00:00:00Z',
+    },
+  },
+];
+
+describe('useDashboardData', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (localStorage.getItem as jest.Mock).mockReturnValue(null);
+    (localStorage.setItem as jest.Mock).mockImplementation(() => {});
+  });
+
+  it('fetches and returns data from API when online', async () => {
+    mockRefreshUser.mockResolvedValue(mockUser);
+    mockGetInvestments.mockResolvedValue(mockInvestments);
+
+    const { result } = renderHook(() => useDashboardData());
+
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.data).toEqual({ user: mockUser, investments: mockInvestments });
+    expect(result.current.isOffline).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('caches successful API response in localStorage', async () => {
+    mockRefreshUser.mockResolvedValue(mockUser);
+    mockGetInvestments.mockResolvedValue(mockInvestments);
+
+    const { result } = renderHook(() => useDashboardData());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      CACHE_KEY,
+      JSON.stringify({ user: mockUser, investments: mockInvestments }),
+    );
+  });
+
+  it('loads cached data from localStorage when API fetch fails', async () => {
+    const cachedData = { user: mockUser, investments: mockInvestments };
+    (localStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+      key === CACHE_KEY ? JSON.stringify(cachedData) : null,
+    );
+
+    mockRefreshUser.mockRejectedValue(new Error('Network Error'));
+    mockGetInvestments.mockRejectedValue(new Error('Network Error'));
+
+    const { result } = renderHook(() => useDashboardData());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.data).toEqual(cachedData);
+    expect(result.current.isOffline).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('returns error when API fails and no cached data exists', async () => {
+    (localStorage.getItem as jest.Mock).mockReturnValue(null);
+    mockRefreshUser.mockRejectedValue(new Error('Service Unavailable'));
+    mockGetInvestments.mockRejectedValue(new Error('Service Unavailable'));
+
+    const { result } = renderHook(() => useDashboardData());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.isOffline).toBe(false);
+    expect(result.current.error).toBe('Service Unavailable');
+  });
+
+  it('starts in loading state', () => {
+    mockRefreshUser.mockResolvedValue(mockUser);
+    mockGetInvestments.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useDashboardData());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+    expect(result.current.isOffline).toBe(false);
+  });
+});

--- a/frontend/src/hooks/useDashboardData.ts
+++ b/frontend/src/hooks/useDashboardData.ts
@@ -1,0 +1,64 @@
+import { useState, useEffect } from 'react';
+import { apiClient, Investment, User } from '../lib/api';
+
+const CACHE_KEY = 'dashboard_data';
+
+export interface DashboardData {
+  user: User | null;
+  investments: Investment[];
+}
+
+export interface UseDashboardDataReturn {
+  data: DashboardData | null;
+  loading: boolean;
+  error: string | null;
+  isOffline: boolean;
+}
+
+export function useDashboardData(): UseDashboardDataReturn {
+  const [data, setData] = useState<DashboardData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isOffline, setIsOffline] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+
+    async function load() {
+      try {
+        const [user, investments] = await Promise.all([
+          apiClient.refreshCurrentUser(),
+          apiClient.getInvestorInvestments(),
+        ]);
+
+        const result: DashboardData = { user, investments };
+        localStorage.setItem(CACHE_KEY, JSON.stringify(result));
+
+        if (active) {
+          setData(result);
+          setIsOffline(false);
+          setError(null);
+        }
+      } catch (err) {
+        const cached = localStorage.getItem(CACHE_KEY);
+        if (active) {
+          if (cached) {
+            setData(JSON.parse(cached) as DashboardData);
+            setIsOffline(true);
+          } else {
+            setError(err instanceof Error ? err.message : 'Failed to load dashboard data');
+          }
+        }
+      } finally {
+        if (active) setLoading(false);
+      }
+    }
+
+    load();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return { data, loading, error, isOffline };
+}


### PR DESCRIPTION
closes #488 - Configure husky pre-commit git hook in the frontend package so the Jest
suite runs automatically before every commit, blocking regressions at the source.

closes #486 - Add `useDashboardData` hook that fetches user and investments from the API
and falls back to a `localStorage` cache when the API is offline; include full spec coverage.

closes #487 - Introduce `applySecurityHeaders` middleware (HSTS, CSP, X-Content-Type-Options)
wired into `main.ts`; add an E2E spec in `backend/test/` asserting all five response headers.

closes #485 - Add `AuditLog` entity and `AuditSubscriber` TypeORM event subscriber that writes
INSERT/UPDATE audit records for every `TradeDeal` change; covered by seven isolated unit tests.
