### PR TITLE
feat(terraform): configure S3 bucket and lifecycle rules for KYC documents (#508)

### DIFF
--- a/devops/terraform/s3.tf
+++ b/devops/terraform/s3.tf
@@ -1,0 +1,47 @@
+# S3 bucket for storing user KYC documents, configured with lifecycle rules
+# to transition older documents to Standard-IA and Glacier to reduce storage costs.
+
+resource "aws_s3_bucket" "kyc_documents" {
+  bucket = "agrifi-kyc-documents"
+
+  tags = {
+    Name    = "agrifi-kyc-documents"
+    Project = "agri-fi"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "kyc_versioning" {
+  bucket = aws_s3_bucket.kyc_documents.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "kyc_encryption" {
+  bucket = aws_s3_bucket.kyc_documents.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "kyc_lifecycle" {
+  bucket = aws_s3_bucket.kyc_documents.id
+
+  rule {
+    id     = "transition-to-standard-ia-and-glacier"
+    status = "Enabled"
+
+    transition {
+      days          = 90
+      storage_class = "STANDARD_IA"
+    }
+
+    transition {
+      days          = 365
+      storage_class = "GLACIER"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Closes #508

Configures an S3 bucket with lifecycle rules to transition KYC documents to colder storage tiers over time to optimize storage costs.

## Proposed Changes
- **S3 Bucket:** Created `aws_s3_bucket.kyc_documents` representing the `agrifi-kyc-documents` bucket.
- **Security & Durability:** Enabled default AES256 server-side encryption (`aws_s3_bucket_server_side_encryption_configuration`) and bucket versioning (`aws_s3_bucket_versioning`).
- **Lifecycle Configuration:**
  - Transition objects to **Standard-IA** (`STANDARD_IA`) after **90 days**.
  - Transition objects to **Glacier** (`GLACIER`) after **1 year (365 days)**.
