### PR TITLE
feat(database): configure RDS read replica and enable backend routing (#506)

### DIFF
--- a/backend/src/database/data-source.ts
+++ b/backend/src/database/data-source.ts
@@ -5,23 +5,38 @@ import * as dotenv from 'dotenv';
 dotenv.config();
 
 const databaseUrl = process.env.DATABASE_URL;
+const databaseReplicaUrl = process.env.DATABASE_REPLICA_URL;
+
+const masterConnection = databaseUrl 
+  ? { url: databaseUrl }
+  : {
+      host: process.env.DATABASE_HOST ?? 'localhost',
+      port: parseInt(process.env.DATABASE_PORT ?? '5432', 10),
+      username: process.env.DATABASE_USER ?? 'postgres',
+      password: process.env.DATABASE_PASSWORD ?? 'postgres',
+      database: process.env.DATABASE_NAME ?? 'agric_onchain',
+    };
+
+const slaveConnection = databaseReplicaUrl
+  ? { url: databaseReplicaUrl }
+  : {
+      host: process.env.DATABASE_REPLICA_HOST ?? process.env.DATABASE_HOST ?? 'localhost',
+      port: parseInt(process.env.DATABASE_PORT ?? '5432', 10),
+      username: process.env.DATABASE_USER ?? 'postgres',
+      password: process.env.DATABASE_PASSWORD ?? 'postgres',
+      database: process.env.DATABASE_NAME ?? 'agric_onchain',
+    };
 
 const dataSourceConfig: any = {
   type: 'postgres',
+  replication: {
+    master: masterConnection,
+    slaves: [slaveConnection],
+  },
   entities: [join(__dirname, '..', '**', '*.entity.{ts,js}')],
   migrations: [join(__dirname, 'migrations', '*.{ts,js}')],
   synchronize: false,
   logging: false,
 };
-
-if (databaseUrl) {
-  dataSourceConfig.url = databaseUrl;
-} else {
-  dataSourceConfig.host = process.env.DATABASE_HOST ?? 'localhost';
-  dataSourceConfig.port = parseInt(process.env.DATABASE_PORT ?? '5432', 10);
-  dataSourceConfig.username = process.env.DATABASE_USER ?? 'postgres';
-  dataSourceConfig.password = process.env.DATABASE_PASSWORD ?? 'postgres';
-  dataSourceConfig.database = process.env.DATABASE_NAME ?? 'agric_onchain';
-}
 
 export const AppDataSource = new DataSource(dataSourceConfig);

--- a/devops/terraform/rds.tf
+++ b/devops/terraform/rds.tf
@@ -76,7 +76,28 @@ resource "aws_db_instance" "postgres" {
   }
 }
 
+resource "aws_db_instance" "postgres_replica" {
+  identifier             = "agrifi-postgres-replica"
+  replicate_source_db    = aws_db_instance.postgres.identifier
+  instance_class         = var.db_instance_class
+  skip_final_snapshot    = true
+  publicly_accessible    = false
+  vpc_security_group_ids = [aws_security_group.postgres.id]
+
+  # Subnet group is inherited from the primary instance, do not specify db_subnet_group_name for replica.
+
+  tags = {
+    Name    = "agrifi-postgres-replica"
+    Project = "agri-fi"
+  }
+}
+
 output "rds_postgres_endpoint" {
-  description = "Connection endpoint for the PostgreSQL instance."
+  description = "Connection endpoint for the PostgreSQL primary instance."
   value       = aws_db_instance.postgres.endpoint
+}
+
+output "rds_postgres_replica_endpoint" {
+  description = "Connection endpoint for the PostgreSQL read replica."
+  value       = aws_db_instance.postgres_replica.endpoint
 }


### PR DESCRIPTION
## Summary
Closes #506

Sets up an RDS read replica in the Terraform configuration and routes all read (retrieve) queries from the NestJS/TypeORM backend to this replica endpoint.

## Proposed Changes
- **Infrastructure (`devops/terraform/rds.tf`):**
  - Added `aws_db_instance.postgres_replica` acting as a replication target of the primary instance (`agrifi-postgres`).
  - Added `rds_postgres_replica_endpoint` output pointing to the replica connection address.
- **Backend Routing (`backend/src/database/data-source.ts`):**
  - Updated TypeORM `DataSource` configuration to leverage its native `replication` capabilities.
  - Read (retrieve) operations are automatically routed to the replica (`DATABASE_REPLICA_URL`/`DATABASE_REPLICA_HOST`), while write operations go to the primary (`DATABASE_URL`/`DATABASE_HOST`).
  - Graceful fallback: If replica settings are absent, it routes queries locally to the primary database to ensure flawless local development.
