### PR TITLE
feat(devops): CloudFront CDN, k8s config/secrets, RabbitMQ cluster, staging CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,98 @@
+name: CD — Staging
+
+# Continuous deployment: on every merge to main, build and push the backend and
+# frontend Docker images to GHCR, then roll the new image tags out to the
+# staging Kubernetes cluster.
+#
+# Required configuration:
+#   * Built-in GITHUB_TOKEN (with packages: write) is used to push to GHCR.
+#   * Secret KUBE_CONFIG_STAGING — base64-encoded kubeconfig for the staging
+#     cluster. Create with: `base64 -w0 ~/.kube/config` (Linux) and store it as
+#     a repository/environment secret.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Never let two staging deploys race each other.
+concurrency:
+  group: cd-staging
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Resolve image coordinates
+    runs-on: ubuntu-latest
+    outputs:
+      image_prefix: ${{ steps.vars.outputs.image_prefix }}
+      tag: ${{ steps.vars.outputs.tag }}
+    steps:
+      - id: vars
+        run: |
+          # GHCR requires a lowercase image path.
+          echo "image_prefix=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+          echo "tag=${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build & push ${{ matrix.component }} image
+    needs: prepare
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        component: [backend, frontend]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./${{ matrix.component }}
+          file: ./${{ matrix.component }}/Dockerfile
+          push: true
+          tags: |
+            ${{ needs.prepare.outputs.image_prefix }}/${{ matrix.component }}:${{ needs.prepare.outputs.tag }}
+            ${{ needs.prepare.outputs.image_prefix }}/${{ matrix.component }}:latest
+          cache-from: type=gha,scope=${{ matrix.component }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.component }}
+
+  deploy:
+    name: Deploy to staging
+    needs: [prepare, build]
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Configure kubeconfig
+        run: |
+          mkdir -p "$HOME/.kube"
+          echo "${{ secrets.KUBE_CONFIG_STAGING }}" | base64 -d > "$HOME/.kube/config"
+
+      - name: Roll out new image tags
+        env:
+          IMAGE_PREFIX: ${{ needs.prepare.outputs.image_prefix }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+        run: |
+          kubectl -n default set image deployment/agri-fi-backend \
+            backend="${IMAGE_PREFIX}/backend:${TAG}"
+          kubectl -n default set image deployment/agri-fi-frontend \
+            frontend="${IMAGE_PREFIX}/frontend:${TAG}"
+
+      - name: Wait for rollout to complete
+        run: |
+          kubectl -n default rollout status deployment/agri-fi-backend --timeout=180s
+          kubectl -n default rollout status deployment/agri-fi-frontend --timeout=180s

--- a/devops/k8s/configmap.yaml
+++ b/devops/k8s/configmap.yaml
@@ -1,0 +1,42 @@
+# Non-sensitive application configuration for the Agri-fi backend and frontend.
+# Sensitive values (DB credentials, JWT/Stellar/encryption keys) live in
+# secrets.yaml — never put passwords or keys in this ConfigMap.
+#
+# Consume in a Deployment with `envFrom`:
+#   envFrom:
+#     - configMapRef:
+#         name: agri-fi-config
+#     - secretRef:
+#         name: agri-fi-secrets
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agri-fi-config
+  namespace: default
+  labels:
+    app: agri-fi
+data:
+  # Runtime
+  NODE_ENV: "production"
+  PORT: "3001"
+  LOG_LEVEL: "info"
+
+  # Database connection (non-secret parts; credentials are in the Secret)
+  DATABASE_HOST: "agri-fi-postgres"
+  DATABASE_PORT: "5432"
+  DATABASE_NAME: "agrifi"
+
+  # Message broker (non-secret parts; credentials are in the Secret)
+  RABBITMQ_HOST: "agri-fi-rabbitmq"
+  RABBITMQ_PORT: "5672"
+
+  # Stellar network
+  STELLAR_NETWORK: "testnet"
+  STELLAR_HORIZON_URL: "https://horizon-testnet.stellar.org"
+
+  # Notifications
+  NOTIFICATIONS_ENABLED: "true"
+
+  # Frontend
+  NEXT_PUBLIC_API_URL: "https://api.agri-fi.example.com"
+  BACKEND_URL: "https://api.agri-fi.example.com"

--- a/devops/k8s/secrets.yaml
+++ b/devops/k8s/secrets.yaml
@@ -1,0 +1,36 @@
+# Secret template for the Agri-fi platform credentials.
+#
+# IMPORTANT: this file is a TEMPLATE. The placeholder values below are NOT real
+# secrets and must never be committed with real values. In a cluster, populate
+# these via one of:
+#   * sealed-secrets / external-secrets-operator (recommended), or
+#   * `kubectl create secret generic agri-fi-secrets --from-literal=...`
+#
+# Application code reads these as environment variables (see backend config and
+# the secrets wired into ecs.tf). Composite connection URLs are kept here too
+# because they embed credentials.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: agri-fi-secrets
+  namespace: default
+  labels:
+    app: agri-fi
+type: Opaque
+stringData:
+  # Database credentials
+  DATABASE_USER: "REPLACE_WITH_DB_USER"
+  DATABASE_PASSWORD: "REPLACE_WITH_DB_PASSWORD"
+  DATABASE_URL: "postgres://REPLACE_WITH_DB_USER:REPLACE_WITH_DB_PASSWORD@agri-fi-postgres:5432/agrifi"
+
+  # Message broker credentials
+  RABBITMQ_USER: "REPLACE_WITH_RABBITMQ_USER"
+  RABBITMQ_PASSWORD: "REPLACE_WITH_RABBITMQ_PASSWORD"
+  RABBITMQ_URL: "amqp://REPLACE_WITH_RABBITMQ_USER:REPLACE_WITH_RABBITMQ_PASSWORD@agri-fi-rabbitmq:5672"
+
+  # Authentication / encryption
+  JWT_SECRET: "REPLACE_WITH_JWT_SECRET"
+  ENCRYPTION_KEY: "REPLACE_WITH_32_CHAR_ENCRYPTION_KEY"
+
+  # Stellar platform signing key
+  STELLAR_PLATFORM_SECRET: "REPLACE_WITH_STELLAR_PLATFORM_SECRET"

--- a/devops/rabbitmq/docker-compose-cluster.yml
+++ b/devops/rabbitmq/docker-compose-cluster.yml
@@ -1,0 +1,142 @@
+# Three-node RabbitMQ cluster for high availability.
+#
+# Removes the single-point-of-failure of the standalone broker in the root
+# docker-compose.yml. Nodes form a cluster via classic (config-based) peer
+# discovery and share a queue-mirroring policy so queues survive the loss of
+# any single node.
+#
+# Run from this directory (devops/rabbitmq):
+#   docker compose -f docker-compose-cluster.yml up -d
+#
+# The shared Erlang cookie below is a development default — override
+# RABBITMQ_ERLANG_COOKIE in every node before using this outside local dev.
+
+x-rabbitmq-common: &rabbitmq-common
+  image: rabbitmq:3-management-alpine
+  environment: &rabbitmq-env
+    RABBITMQ_ERLANG_COOKIE: ${RABBITMQ_ERLANG_COOKIE:-agri-fi-cluster-cookie}
+    RABBITMQ_DEFAULT_USER: ${RABBITMQ_DEFAULT_USER:-guest}
+    RABBITMQ_DEFAULT_PASS: ${RABBITMQ_DEFAULT_PASS:-guest}
+  configs:
+    - source: rabbitmq_cluster_conf
+      target: /etc/rabbitmq/rabbitmq.conf
+    - source: rabbitmq_definitions
+      target: /etc/rabbitmq/definitions.json
+  healthcheck:
+    test: ["CMD-SHELL", "rabbitmq-diagnostics -q ping"]
+    interval: 15s
+    timeout: 10s
+    retries: 5
+  restart: unless-stopped
+  networks:
+    - rabbitmq-cluster
+
+services:
+  rabbitmq1:
+    <<: *rabbitmq-common
+    hostname: rabbitmq1
+    container_name: agri-fi-rabbitmq1
+    environment:
+      <<: *rabbitmq-env
+      RABBITMQ_NODENAME: rabbit@rabbitmq1
+    ports:
+      - '5672:5672'    # AMQP
+      - '15672:15672'  # management UI
+      - '15692:15692'  # prometheus metrics
+    volumes:
+      - ./enabled_plugins:/etc/rabbitmq/enabled_plugins:ro
+      - rabbitmq1-data:/var/lib/rabbitmq
+
+  rabbitmq2:
+    <<: *rabbitmq-common
+    hostname: rabbitmq2
+    container_name: agri-fi-rabbitmq2
+    environment:
+      <<: *rabbitmq-env
+      RABBITMQ_NODENAME: rabbit@rabbitmq2
+    ports:
+      - '5673:5672'
+      - '15673:15672'
+    volumes:
+      - ./enabled_plugins:/etc/rabbitmq/enabled_plugins:ro
+      - rabbitmq2-data:/var/lib/rabbitmq
+    depends_on:
+      rabbitmq1:
+        condition: service_healthy
+
+  rabbitmq3:
+    <<: *rabbitmq-common
+    hostname: rabbitmq3
+    container_name: agri-fi-rabbitmq3
+    environment:
+      <<: *rabbitmq-env
+      RABBITMQ_NODENAME: rabbit@rabbitmq3
+    ports:
+      - '5674:5672'
+      - '15674:15672'
+    volumes:
+      - ./enabled_plugins:/etc/rabbitmq/enabled_plugins:ro
+      - rabbitmq3-data:/var/lib/rabbitmq
+    depends_on:
+      rabbitmq1:
+        condition: service_healthy
+
+configs:
+  # Cluster configuration: classic config-based peer discovery lists every node
+  # so they auto-form a single cluster on boot. Prometheus/management/logging
+  # mirror the standalone rabbitmq.conf in this directory.
+  rabbitmq_cluster_conf:
+    content: |
+      # Cluster formation via classic (static) peer discovery.
+      cluster_formation.peer_discovery_backend = classic_config
+      cluster_formation.classic_config.nodes.1 = rabbit@rabbitmq1
+      cluster_formation.classic_config.nodes.2 = rabbit@rabbitmq2
+      cluster_formation.classic_config.nodes.3 = rabbit@rabbitmq3
+
+      # Re-join the cluster cleanly after a restart / network partition.
+      cluster_partition_handling = autoheal
+
+      # Load the mirroring (HA) policy at boot.
+      load_definitions = /etc/rabbitmq/definitions.json
+
+      # Prometheus metrics endpoint.
+      prometheus.tcp.port = 15692
+      prometheus.path = /metrics
+      prometheus.return_per_object_metrics = true
+
+      # Management plugin.
+      management.tcp.port = 15672
+      management.tcp.ip = 0.0.0.0
+
+      # Logging.
+      log.console = true
+      log.console.level = info
+
+  # Mirror every queue across all nodes so a queue survives losing any node.
+  rabbitmq_definitions:
+    content: |
+      {
+        "vhosts": [{ "name": "/" }],
+        "policies": [
+          {
+            "vhost": "/",
+            "name": "ha-all",
+            "pattern": ".*",
+            "apply-to": "queues",
+            "priority": 0,
+            "definition": {
+              "ha-mode": "all",
+              "ha-sync-mode": "automatic"
+            }
+          }
+        ]
+      }
+
+volumes:
+  rabbitmq1-data:
+  rabbitmq2-data:
+  rabbitmq3-data:
+
+networks:
+  rabbitmq-cluster:
+    driver: bridge

--- a/devops/terraform/cloudfront.tf
+++ b/devops/terraform/cloudfront.tf
@@ -1,0 +1,178 @@
+# CloudFront distribution fronting the Agri-fi platform.
+#
+# Two origins are wired up:
+#   * An S3 bucket dedicated to immutable static assets (cached aggressively at
+#     the edge via the managed CachingOptimized policy). It is locked down with
+#     an Origin Access Control so the bucket itself stays private — only
+#     CloudFront can read objects.
+#   * The Next.js frontend behind the existing ALB (see ecs.tf). Dynamic /
+#     server-rendered responses use the managed CachingDisabled policy so the
+#     edge never serves stale HTML, while still terminating TLS and absorbing
+#     connections at the edge.
+#
+# The KYC documents bucket (s3.tf) is intentionally NOT exposed through the CDN.
+
+# Dedicated bucket for CDN-served static assets, kept private behind OAC.
+resource "aws_s3_bucket" "static_assets" {
+  bucket = "agrifi-static-assets"
+
+  tags = {
+    Name    = "agrifi-static-assets"
+    Project = "agri-fi"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "static_assets" {
+  bucket = aws_s3_bucket.static_assets.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "static_assets" {
+  bucket = aws_s3_bucket.static_assets.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+# Origin Access Control lets CloudFront sign requests to the private S3 origin.
+resource "aws_cloudfront_origin_access_control" "static_assets" {
+  name                              = "agri-fi-static-assets-oac"
+  description                       = "OAC for the Agri-fi static assets bucket"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+locals {
+  s3_origin_id  = "agri-fi-static-assets-s3"
+  alb_origin_id = "agri-fi-nextjs-alb"
+
+  # AWS managed cache / origin-request / response-header policy IDs.
+  # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html
+  cache_policy_caching_optimized    = "658327ea-f89d-4fab-a63d-7e88639e58f6"
+  cache_policy_caching_disabled     = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad"
+  origin_request_all_viewer_no_host = "b689b0a8-53d0-40ab-baf2-68738e2966ac"
+  response_headers_security         = "67f7725c-6f97-4210-82d7-5512b31e9d03"
+}
+
+resource "aws_cloudfront_distribution" "agri_fi" {
+  enabled         = true
+  is_ipv6_enabled = true
+  comment         = "Agri-fi platform CDN"
+  price_class     = "PriceClass_100"
+  aliases         = [var.domain_name, "www.${var.domain_name}"]
+
+  # Static assets origin (private S3 bucket via OAC).
+  origin {
+    domain_name              = aws_s3_bucket.static_assets.bucket_regional_domain_name
+    origin_id                = local.s3_origin_id
+    origin_access_control_id = aws_cloudfront_origin_access_control.static_assets.id
+  }
+
+  # Next.js frontend origin (the ALB from ecs.tf).
+  origin {
+    domain_name = aws_lb.agri_fi.dns_name
+    origin_id   = local.alb_origin_id
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  # Default behaviour: dynamic Next.js traffic — never cached at the edge.
+  default_cache_behavior {
+    target_origin_id           = local.alb_origin_id
+    viewer_protocol_policy     = "redirect-to-https"
+    allowed_methods            = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
+    cached_methods             = ["GET", "HEAD"]
+    compress                   = true
+    cache_policy_id            = local.cache_policy_caching_disabled
+    origin_request_policy_id   = local.origin_request_all_viewer_no_host
+    response_headers_policy_id = local.response_headers_security
+  }
+
+  # Next.js build output is content-hashed and immutable — cache it hard.
+  ordered_cache_behavior {
+    path_pattern           = "/_next/static/*"
+    target_origin_id       = local.alb_origin_id
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+    cache_policy_id        = local.cache_policy_caching_optimized
+  }
+
+  # Static assets served straight from S3.
+  ordered_cache_behavior {
+    path_pattern           = "/static/*"
+    target_origin_id       = local.s3_origin_id
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+    cache_policy_id        = local.cache_policy_caching_optimized
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  # The ACM certificate (ecs.tf) must live in us-east-1 for CloudFront to use it.
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate.agri_fi.arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  tags = {
+    Name    = "agri-fi-cdn"
+    Project = "agri-fi"
+  }
+}
+
+# Allow the CloudFront distribution (and only it) to read static assets.
+data "aws_iam_policy_document" "static_assets_oac" {
+  statement {
+    sid       = "AllowCloudFrontServicePrincipalReadOnly"
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.static_assets.arn}/*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [aws_cloudfront_distribution.agri_fi.arn]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "static_assets" {
+  bucket = aws_s3_bucket.static_assets.id
+  policy = data.aws_iam_policy_document.static_assets_oac.json
+}
+
+output "cloudfront_distribution_domain_name" {
+  description = "Domain name of the CloudFront distribution (feed this into var.cloudfront_domain_name for dns.tf)."
+  value       = aws_cloudfront_distribution.agri_fi.domain_name
+}
+
+output "cloudfront_distribution_id" {
+  description = "ID of the CloudFront distribution."
+  value       = aws_cloudfront_distribution.agri_fi.id
+}


### PR DESCRIPTION
## Summary

DevOps configuration for the Agri-fi platform, bundling four assigned issues into one PR. All files are new and self-contained; no existing infra is modified.

- **#507 — CloudFront CDN** (`devops/terraform/cloudfront.tf`): a distribution with two origins — a dedicated, private S3 static-assets bucket locked down with an Origin Access Control, and the existing Next.js ALB (from `ecs.tf`) for dynamic traffic. Caching is driven by AWS managed cache policies: `CachingDisabled` for dynamic Next.js responses, `CachingOptimized` for `/_next/static/*` and `/static/*`. The existing private KYC bucket (`s3.tf`) is intentionally **not** exposed via the CDN. Outputs the distribution domain for `dns.tf`'s `cloudfront_domain_name`.
- **#505 — K8s ConfigMap & Secrets** (`devops/k8s/configmap.yaml`, `secrets.yaml`): non-sensitive runtime/DB/RabbitMQ/Stellar/frontend config in a ConfigMap; credentials and composite connection URLs in an Opaque Secret **template** with placeholder values (documented to be injected via sealed-secrets / external-secrets / `kubectl create secret`, never committed real). Env var names mirror those wired into `ecs.tf` and the backend CI.
- **#503 — RabbitMQ cluster** (`devops/rabbitmq/docker-compose-cluster.yml`): three nodes forming a cluster via classic config-based peer discovery, a shared Erlang cookie, `autoheal` partition handling, and an `ha-all` policy (`ha-mode: all`, `ha-sync-mode: automatic`) so queues survive losing any node. Reuses the repo's existing `enabled_plugins`; Prometheus/management/logging settings mirror `rabbitmq.conf`.
- **#502 — Staging CD** (`.github/workflows/cd.yml`): on merge to `main`, builds and pushes the backend and frontend images to GHCR (matrix build, gha cache), then updates the staging Kubernetes deployment image tags and waits for the rollout.

## Test plan

- [x] All YAML manifests parse (k8s ConfigMap/Secret, RabbitMQ compose, `cd.yml`).
- [x] Terraform formatted to `terraform fmt` conventions; references existing resources (`aws_lb.agri_fi`, `aws_acm_certificate.agri_fi`) and matches the project's naming/tagging style.
- [ ] `terraform validate`/`plan` against a configured AWS provider (requires credentials — not run here).
- [ ] `docker compose -f docker-compose-cluster.yml up -d` brings up a healthy 3-node cluster (requires Docker — not run here).
- [ ] CD workflow run requires the `KUBE_CONFIG_STAGING` secret and a reachable staging cluster.

Closes #507
Closes #505
Closes #503
Closes #502