### PR TITLE
Harden backend auth config and add Jest watch launchers

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Backend: Jest watch",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "npm run test:watch",
+      "cwd": "${workspaceFolder}/backend"
+    },
+    {
+      "name": "Backend: Jest e2e watch",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "npm run test:e2e -- --watch",
+      "cwd": "${workspaceFolder}/backend"
+    }
+  ]
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -22,6 +22,7 @@ import { TerminusModule } from '@nestjs/terminus';
 import { ThrottlerModule } from '@nestjs/throttler';
 import { SorobanModule } from './soroban/soroban.module';
 import { MetricsModule } from './metrics/metrics.module';
+import { validateEnvironment } from './config/env.validation';
 
 @Module({
   imports: [
@@ -38,6 +39,7 @@ import { MetricsModule } from './metrics/metrics.module';
     ConfigModule.forRoot({
       isGlobal: true,
       envFilePath: '.env',
+      validate: validateEnvironment,
     }),
     TypeOrmModule.forRootAsync({
       imports: [ConfigModule],

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -22,7 +22,7 @@ import { QueueModule } from '../queue/queue.module';
       imports: [ConfigModule],
       inject: [ConfigService],
       useFactory: (config: ConfigService) => ({
-        secret: config.get<string>('JWT_SECRET', 'change_me'),
+        secret: config.getOrThrow<string>('JWT_SECRET'),
         signOptions: { expiresIn: config.get<string>('JWT_EXPIRES_IN', '7d') },
       }),
     }),

--- a/backend/src/auth/jwt.strategy.ts
+++ b/backend/src/auth/jwt.strategy.ts
@@ -23,7 +23,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
-      secretOrKey: config.get<string>('JWT_SECRET', 'change_me'),
+      secretOrKey: config.getOrThrow<string>('JWT_SECRET'),
     });
   }
 

--- a/backend/src/config/env.validation.ts
+++ b/backend/src/config/env.validation.ts
@@ -1,0 +1,13 @@
+import { ConfigFactory } from '@nestjs/config';
+
+export const validateEnvironment: ConfigFactory = () => {
+  const jwtSecret = process.env.JWT_SECRET?.trim();
+
+  if (!jwtSecret) {
+    throw new Error('JWT_SECRET is required for backend startup.');
+  }
+
+  return {
+    JWT_SECRET: jwtSecret,
+  };
+};


### PR DESCRIPTION
Adds fail-fast JWT secret validation and VS Code launch targets for Jest watch mode.

Closes #463
Closes #460
Closes #461
Closes #458