### PR TITLE
feat: add Implement-rate-limiting

### DIFF
--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -1,0 +1,78 @@
+name: Docker Image Security Scan
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - "backend/Dockerfile"
+      - "frontend/Dockerfile"
+      - ".github/workflows/docker-scan.yml"
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - "backend/Dockerfile"
+      - "frontend/Dockerfile"
+      - ".github/workflows/docker-scan.yml"
+  workflow_dispatch: {}
+
+jobs:
+  trivy-scan:
+    name: Trivy Container Vulnerability Scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write   # Required to upload SARIF results to GitHub Security tab
+
+    strategy:
+      fail-fast: true           # Halt all matrix jobs if any critical vuln is found
+      matrix:
+        include:
+          - context: ./backend
+            image: agri-fi-backend
+            dockerfile: backend/Dockerfile
+          - context: ./frontend
+            image: agri-fi-frontend
+            dockerfile: frontend/Dockerfile
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # ------------------------------------------------------------------ #
+      # Build the Docker image so Trivy has a local image to scan           #
+      # ------------------------------------------------------------------ #
+      - name: Build Docker image (${{ matrix.image }})
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: false
+          tags: ${{ matrix.image }}:scan-${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # ------------------------------------------------------------------ #
+      # Run Trivy — halt on CRITICAL findings                               #
+      # ------------------------------------------------------------------ #
+      - name: Run Trivy vulnerability scan (${{ matrix.image }})
+        uses: aquasecurity/trivy-action@0.24.0
+        with:
+          image-ref: "${{ matrix.image }}:scan-${{ github.sha }}"
+          format: "sarif"
+          output: "trivy-results-${{ matrix.image }}.sarif"
+          # EXIT_CODE 1 causes the step — and therefore the job — to fail,
+          # which blocks deployment when critical vulnerabilities are found.
+          exit-code: "1"
+          ignore-unfixed: false
+          vuln-type: "os,library"
+          severity: "CRITICAL"
+
+      # ------------------------------------------------------------------ #
+      # Upload SARIF to the GitHub Security tab (runs even on failure)      #
+      # ------------------------------------------------------------------ #
+      - name: Upload Trivy SARIF to GitHub Security tab (${{ matrix.image }})
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: "trivy-results-${{ matrix.image }}.sarif"
+          category: "trivy-${{ matrix.image }}"

--- a/backend/src/database/migrations/1716300000009-EnableRLS.ts
+++ b/backend/src/database/migrations/1716300000009-EnableRLS.ts
@@ -1,0 +1,63 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Enables Row Level Security (RLS) on the `investments` and `transaction_logs`
+ * tables and defines tenant-isolation policies that check the active tenant ID
+ * stored in the PostgreSQL session variable `app.current_tenant_id`.
+ *
+ * Application code MUST call:
+ *   SET LOCAL app.current_tenant_id = '<tenant-uuid>';
+ * inside the same transaction/session before any DML on these tables.
+ */
+export class EnableRLS1716300000009 implements MigrationInterface {
+  name = 'EnableRLS1716300000009';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // ------------------------------------------------------------------ //
+    // investments
+    // ------------------------------------------------------------------ //
+    await queryRunner.query(`ALTER TABLE "investments" ENABLE ROW LEVEL SECURITY`);
+
+    // Bypass RLS for superusers / migration runner (FORCE applies to owners too)
+    await queryRunner.query(`ALTER TABLE "investments" FORCE ROW LEVEL SECURITY`);
+
+    // Allow a row to be seen / modified only when the investor's tenant matches
+    // the active session tenant context.
+    await queryRunner.query(`
+      CREATE POLICY "investments_tenant_isolation"
+      ON "investments"
+      USING (
+        "investor_id" IN (
+          SELECT id FROM users
+          WHERE tenant_id = current_setting('app.current_tenant_id', true)::uuid
+        )
+      )
+    `);
+
+    // ------------------------------------------------------------------ //
+    // transaction_logs
+    // ------------------------------------------------------------------ //
+    await queryRunner.query(`ALTER TABLE "transaction_logs" ENABLE ROW LEVEL SECURITY`);
+
+    await queryRunner.query(`ALTER TABLE "transaction_logs" FORCE ROW LEVEL SECURITY`);
+
+    await queryRunner.query(`
+      CREATE POLICY "transaction_logs_tenant_isolation"
+      ON "transaction_logs"
+      USING (
+        "user_id" IN (
+          SELECT id FROM users
+          WHERE tenant_id = current_setting('app.current_tenant_id', true)::uuid
+        )
+      )
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP POLICY IF EXISTS "transaction_logs_tenant_isolation" ON "transaction_logs"`);
+    await queryRunner.query(`ALTER TABLE "transaction_logs" DISABLE ROW LEVEL SECURITY`);
+
+    await queryRunner.query(`DROP POLICY IF EXISTS "investments_tenant_isolation" ON "investments"`);
+    await queryRunner.query(`ALTER TABLE "investments" DISABLE ROW LEVEL SECURITY`);
+  }
+}

--- a/backend/src/documents/documents.controller.ts
+++ b/backend/src/documents/documents.controller.ts
@@ -8,6 +8,8 @@ import {
   Request,
   BadRequestException,
 } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
+import { createHash } from 'crypto';
 import {
   ApiTags,
   ApiOperation,
@@ -29,9 +31,13 @@ interface AuthRequest extends Request {
 @ApiBearerAuth('jwt')
 @Controller('documents')
 export class DocumentsController {
+  /** In-memory cache: SHA-256(fileBuffer) → upload result, to avoid redundant IPFS calls */
+  private readonly ipfsCache = new Map<string, object>();
+
   constructor(private readonly documentsService: DocumentsService) {}
 
   @Post()
+  @Throttle({ default: { limit: 20, ttl: 60000 } })
   @UseGuards(AuthGuard('jwt'))
   @UseInterceptors(FileInterceptor('file'))
   @ApiOperation({
@@ -66,6 +72,7 @@ export class DocumentsController {
   })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Trade deal not found' })
+  @ApiResponse({ status: 429, description: 'Too Many Requests – IPFS proxy limit is 20 per minute' })
   async uploadDocument(
     @UploadedFile() file: Express.Multer.File,
     @Body() body: { doc_type: string; trade_deal_id: string },
@@ -81,11 +88,23 @@ export class DocumentsController {
         'Unsupported file type. Only PDF, PNG, JPEG allowed',
       );
     }
-    return this.documentsService.handleUpload({
+
+    // Cache IPFS files locally by content hash to limit external node calls.
+    // If the exact same file bytes were previously uploaded, return the cached
+    // result without hitting the IPFS gateway again.
+    const contentKey = createHash('sha256').update(file.buffer).digest('hex');
+    if (this.ipfsCache.has(contentKey)) {
+      return this.ipfsCache.get(contentKey);
+    }
+
+    const result = await this.documentsService.handleUpload({
       file,
       docType: body.doc_type,
       tradeDealId: body.trade_deal_id,
       userId: req.user.id,
     });
+
+    this.ipfsCache.set(contentKey, result);
+    return result;
   }
 }

--- a/devops/ansible/hosts.yaml
+++ b/devops/ansible/hosts.yaml
@@ -1,0 +1,53 @@
+---
+# Ansible inventory for agri-fi servers
+# SSH hardening: password authentication is disabled; only Ed25519 keys are accepted.
+
+all:
+  vars:
+    # -----------------------------------------------------------------------
+    # Global SSH hardening settings applied via the sshd role / lineinfile tasks
+    # -----------------------------------------------------------------------
+    ansible_ssh_private_key_file: "~/.ssh/id_ed25519"
+    ansible_ssh_common_args: "-o StrictHostKeyChecking=accept-new"
+
+    # sshd_config parameters enforced on every managed host
+    sshd_config:
+      PasswordAuthentication: "no"
+      ChallengeResponseAuthentication: "no"
+      UsePAM: "yes"
+      PermitRootLogin: "prohibit-password"
+      PubkeyAuthentication: "yes"
+      # Restrict accepted key types to Ed25519 only (no RSA/DSA/ECDSA)
+      PubkeyAcceptedAlgorithms: "ssh-ed25519,sk-ssh-ed25519@openssh.com"
+      AuthorizedKeysFile: ".ssh/authorized_keys"
+      # Harden further
+      X11Forwarding: "no"
+      AllowAgentForwarding: "no"
+      PermitEmptyPasswords: "no"
+      MaxAuthTries: "3"
+      LoginGraceTime: "30"
+
+  children:
+    webservers:
+      hosts:
+        web01:
+          ansible_host: "{{ lookup('env', 'WEB01_HOST') }}"
+          ansible_user: deploy
+        web02:
+          ansible_host: "{{ lookup('env', 'WEB02_HOST') }}"
+          ansible_user: deploy
+
+    db_servers:
+      hosts:
+        db01:
+          ansible_host: "{{ lookup('env', 'DB01_HOST') }}"
+          ansible_user: deploy
+
+    app_servers:
+      hosts:
+        app01:
+          ansible_host: "{{ lookup('env', 'APP01_HOST') }}"
+          ansible_user: deploy
+        app02:
+          ansible_host: "{{ lookup('env', 'APP02_HOST') }}"
+          ansible_user: deploy


### PR DESCRIPTION
closes #431 
closes #432 
closes #434 
closes #435 


## 1. IPFS Rate Limiting + Local Cache — 

documents.controller.ts
Added @Throttle({ default: { limit: 20, ttl: 60000 } }) on the POST /documents route → max 20 downloads per minute
Added a private ipfsCache: Map<sha256 → result> on the controller. Before calling documentsService.handleUpload(), the handler computes a SHA-256 of the file buffer and returns the cached result if the exact same bytes were already uploaded — no redundant IPFS gateway hit

## 2. RLS Migration — 

1716300000009-EnableRLS.ts
 (NEW)
Enables ROW LEVEL SECURITY + FORCE ROW LEVEL SECURITY on investments and transaction_logs
Creates USING policies that filter rows to only those belonging to the tenant whose UUID is in the PostgreSQL session variable app.current_tenant_id
down() cleanly drops policies and disables RLS

## 3. Ansible SSH Hardening — 

devops/ansible/hosts.yaml
 (NEW)
Sets PasswordAuthentication: "no" and ChallengeResponseAuthentication: "no" globally
Restricts PubkeyAcceptedAlgorithms to Ed25519 (ssh-ed25519,sk-ssh-ed25519@openssh.com) only
Hardens further: PermitRootLogin: prohibit-password, MaxAuthTries: 3, PermitEmptyPasswords: no

## 4. Trivy Container Scanner CI — 

.github/workflows/docker-scan.yml
 (NEW)
Runs a matrix build + Trivy scan for both backend and frontend Dockerfiles
exit-code: "1" on CRITICAL severity → job fails and blocks deployment
Uploads SARIF results to GitHub Security tab even on failure for visibility