### PR TITLE
fix(#398): sanitize commodity search input to prevent SQL injection

### DIFF
--- a/backend/src/trade-deals/trade-deals.service.ts
+++ b/backend/src/trade-deals/trade-deals.service.ts
@@ -134,6 +134,10 @@ export class TradeDealsService {
     const limit = query.limit ?? 12;
     const skip = (page - 1) * limit;
 
+    if (query.commodity && !/^[a-zA-Z0-9 _-]{1,100}$/.test(query.commodity)) {
+      throw new BadRequestException('Invalid commodity search term.');
+    }
+
     const qb = this.tradeDealRepo
       .createQueryBuilder('deal')
       .where('deal.status = :status', { status: 'open' })


### PR DESCRIPTION
Sanitize search inputs to prevent SQL injection
  │ 
  │ Adds an allowlist regex guard in TradeDealsService.findOpen() that rejects any commodity
  search value not matching ^[a-zA-Z0-9 _-]{1,100}$ with a 400 Bad Request. The underlying
  QueryBuilder already uses parameterized queries; this adds an explicit input validation layer
  before execution.

closes #398 