### PR TITLE
fix: validate document CIDs and travel rule data

### DIFF
--- a/backend/src/documents/documents.service.ts
+++ b/backend/src/documents/documents.service.ts
@@ -1,10 +1,11 @@
-import { Injectable } from '@nestjs/common';
+import { BadGatewayException, Injectable } from '@nestjs/common';
 import { StorageService } from '../storage/storage.service';
 import { StellarService } from '../stellar/stellar.service';
 import { TradeDealsService } from '../trade-deals/trade-deals.service';
 import { ConfigService } from '@nestjs/config';
 import { createHash } from 'crypto';
 import { buildDocumentMemo } from '../stellar/anchor-memo';
+import { isValidIpfsCid } from './ipfs-cid';
 
 @Injectable()
 export class DocumentsService {
@@ -31,6 +32,10 @@ export class DocumentsService {
       file.buffer,
       file.mimetype,
     );
+
+    if (!isValidIpfsCid(hash)) {
+      throw new BadGatewayException('Storage provider returned an invalid IPFS CID.');
+    }
 
     // 2. Calculate SHA-256 of the file for Stellar Anchoring
     const fileHash = createHash('sha256').update(file.buffer).digest('hex');

--- a/backend/src/documents/ipfs-cid.ts
+++ b/backend/src/documents/ipfs-cid.ts
@@ -1,0 +1,85 @@
+const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+function decodeBase58(value: string): Uint8Array | null {
+  const bytes = [0];
+
+  for (const char of value) {
+    const digit = BASE58_ALPHABET.indexOf(char);
+    if (digit === -1) return null;
+
+    let carry = digit;
+    for (let index = 0; index < bytes.length; index += 1) {
+      const next = bytes[index] * 58 + carry;
+      bytes[index] = next & 0xff;
+      carry = next >> 8;
+    }
+
+    while (carry > 0) {
+      bytes.push(carry & 0xff);
+      carry >>= 8;
+    }
+  }
+
+  for (const char of value) {
+    if (char !== '1') break;
+    bytes.push(0);
+  }
+
+  return Uint8Array.from(bytes.reverse());
+}
+
+function decodeBase32(value: string): Uint8Array | null {
+  if (!/^b[a-z2-7]+$/.test(value)) return null;
+
+  const alphabet = 'abcdefghijklmnopqrstuvwxyz234567';
+  let buffer = 0;
+  let bits = 0;
+  const bytes: number[] = [];
+
+  for (const char of value.slice(1)) {
+    buffer = (buffer << 5) | alphabet.indexOf(char);
+    bits += 5;
+    if (bits >= 8) {
+      bytes.push((buffer >>> (bits - 8)) & 0xff);
+      bits -= 8;
+    }
+  }
+
+  return Uint8Array.from(bytes);
+}
+
+function readVarint(bytes: Uint8Array, offset: number): number | null {
+  let value = 0;
+  let shift = 0;
+
+  for (let index = offset; index < bytes.length && shift < 35; index += 1) {
+    const byte = bytes[index];
+    value |= (byte & 0x7f) << shift;
+    if ((byte & 0x80) === 0) return index + 1;
+    shift += 7;
+  }
+
+  return null;
+}
+
+export function isValidIpfsCid(value: string): boolean {
+  if (!value || /\s/.test(value)) return false;
+
+  if (/^Qm[1-9A-HJ-NP-Za-km-z]{44}$/.test(value)) {
+    const bytes = decodeBase58(value);
+    return bytes?.length === 34 && bytes[0] === 0x12 && bytes[1] === 0x20;
+  }
+
+  const bytes = value.startsWith('b') ? decodeBase32(value) : null;
+  if (!bytes) return false;
+
+  const versionEnd = readVarint(bytes, 0);
+  if (versionEnd === null || bytes[0] !== 1) return false;
+
+  const codecEnd = readVarint(bytes, versionEnd);
+  const hashCodeEnd = codecEnd === null ? null : readVarint(bytes, codecEnd);
+  const digestLengthEnd =
+    hashCodeEnd === null ? null : readVarint(bytes, hashCodeEnd);
+
+  return digestLengthEnd !== null && digestLengthEnd < bytes.length;
+}

--- a/backend/src/investments/dto/create-investment.dto.ts
+++ b/backend/src/investments/dto/create-investment.dto.ts
@@ -44,8 +44,16 @@ export class CreateInvestmentDto {
     description:
       'Originator and beneficiary metadata for FATF Travel Rule readiness on large transfers.',
     example: {
-      originator: { name: 'Ada Investor', walletAddress: 'GINVESTOR...' },
-      beneficiary: { name: 'Agri-Fi Escrow', walletAddress: 'GESCROW...' },
+      originator: {
+        name: 'Ada Investor',
+        address: '1 Market Street, Nairobi',
+        accountNumber: 'GINVESTOR...',
+      },
+      beneficiary: {
+        name: 'Agri-Fi Escrow',
+        address: '1 Finance Avenue, Nairobi',
+        accountNumber: 'GESCROW...',
+      },
     },
   })
   @IsOptional()

--- a/backend/src/investments/investments.service.ts
+++ b/backend/src/investments/investments.service.ts
@@ -29,6 +29,13 @@ export interface CreateInvestmentResult {
 }
 
 const STELLAR_TX_HASH_PATTERN = /^[a-f0-9]{64}$/i;
+const TRAVEL_RULE_THRESHOLD_USD = 1000;
+
+type TravelRuleParty = {
+  name?: unknown;
+  address?: unknown;
+  accountNumber?: unknown;
+};
 
 @Injectable()
 export class InvestmentsService {
@@ -48,6 +55,8 @@ export class InvestmentsService {
     investorId: string,
     dto: CreateInvestmentDto,
   ): Promise<CreateInvestmentResult> {
+    this.assertTravelRuleCompliance(dto.amountUsd, dto.complianceData);
+
     // Load investor to get their wallet address for the XDR
     const investor = await this.userRepo.findOne({ where: { id: investorId } });
     if (!investor) {
@@ -159,6 +168,32 @@ export class InvestmentsService {
     );
 
     return { investment, unsignedXdr };
+  }
+
+  private assertTravelRuleCompliance(
+    amountUsd: number,
+    complianceData?: Record<string, unknown>,
+  ): void {
+    if (amountUsd <= TRAVEL_RULE_THRESHOLD_USD) return;
+
+    const hasRequiredFields = (party: unknown): party is TravelRuleParty => {
+      if (!party || typeof party !== 'object') return false;
+      const { name, address, accountNumber } = party as TravelRuleParty;
+      return [name, address, accountNumber].every(
+        (field) => typeof field === 'string' && field.trim().length > 0,
+      );
+    };
+
+    if (
+      !hasRequiredFields(complianceData?.originator) ||
+      !hasRequiredFields(complianceData?.beneficiary)
+    ) {
+      throw new BadRequestException({
+        code: 'TRAVEL_RULE_DATA_REQUIRED',
+        message:
+          'Investments above $1,000 require originator and beneficiary name, address, and account number.',
+      });
+    }
   }
 
   async confirmInvestment(


### PR DESCRIPTION
## Summary

- Validate IPFS CIDv0 and CIDv1 values returned by document storage.
- Reject invalid CIDs before document records are persisted.
- Require complete FATF Travel Rule data for investments above $1,000.

Closes #407  
Closes #408 
Closes  #410
Closes #411