### PR TITLE
feat: implement security issues Add csurf middleware + cookie-parser to main.ts; expose GET /csrf-token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,53 @@
+# Kiro
 .kiro
+
+# Dependencies
 node_modules
 */node_modules
+
+# Build output
 dist
 build
 .next
-.eslintcache
-*.log
+out
 
+# Environment files
+.env
+.env.*
+!.env.example
+
+# Logs
+*.log
+logs/
+
+# Test artifacts
+coverage/
+__snapshots__/
+*.snap
+*.lcov
+junit.xml
+test-results/
+
+# Cache
+.eslintcache
+.tsbuildinfo
+*.tsbuildinfo
+.turbo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Editor
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Temp
+/tmp
+*.pgdump
+*.pgdump.enc
+
+# Misc
 fix.md

--- a/backend/scripts/backup.sh
+++ b/backend/scripts/backup.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# backup.sh — pg_dump → AES-256 encrypt → S3 upload
+# Required env vars:
+#   DATABASE_URL          postgres connection string
+#   BACKUP_ENCRYPTION_KEY AES-256 passphrase (or fetched from AWS Secrets Manager)
+#   BACKUP_S3_BUCKET      destination S3 bucket name
+#   BACKUP_S3_PREFIX      (optional) key prefix, defaults to "backups"
+#   AWS_SECRET_ID         (optional) AWS Secrets Manager secret id for the encryption key
+
+set -euo pipefail
+
+TIMESTAMP=$(date -u +"%Y%m%dT%H%M%SZ")
+DUMP_FILE="/tmp/agri-fi-${TIMESTAMP}.pgdump"
+ENCRYPTED_FILE="${DUMP_FILE}.enc"
+S3_PREFIX="${BACKUP_S3_PREFIX:-backups}"
+S3_KEY="${S3_PREFIX}/agri-fi-${TIMESTAMP}.pgdump.enc"
+
+# ── Fetch encryption key ─────────────────────────────────────────────────────
+if [[ -n "${AWS_SECRET_ID:-}" ]]; then
+  BACKUP_ENCRYPTION_KEY=$(aws secretsmanager get-secret-value \
+    --secret-id "${AWS_SECRET_ID}" \
+    --query SecretString \
+    --output text)
+fi
+
+if [[ -z "${BACKUP_ENCRYPTION_KEY:-}" ]]; then
+  echo "ERROR: BACKUP_ENCRYPTION_KEY is not set." >&2
+  exit 1
+fi
+
+if [[ -z "${BACKUP_S3_BUCKET:-}" ]]; then
+  echo "ERROR: BACKUP_S3_BUCKET is not set." >&2
+  exit 1
+fi
+
+# ── Dump ─────────────────────────────────────────────────────────────────────
+echo "Running pg_dump..."
+pg_dump "${DATABASE_URL}" --format=custom --no-password --file="${DUMP_FILE}"
+
+# ── Encrypt (AES-256-CBC via openssl) ────────────────────────────────────────
+echo "Encrypting backup..."
+openssl enc -aes-256-cbc -salt -pbkdf2 -iter 600000 \
+  -pass "pass:${BACKUP_ENCRYPTION_KEY}" \
+  -in "${DUMP_FILE}" \
+  -out "${ENCRYPTED_FILE}"
+
+# ── Upload to S3 ─────────────────────────────────────────────────────────────
+echo "Uploading to s3://${BACKUP_S3_BUCKET}/${S3_KEY} ..."
+aws s3 cp "${ENCRYPTED_FILE}" "s3://${BACKUP_S3_BUCKET}/${S3_KEY}" \
+  --storage-class STANDARD_IA
+
+# ── Cleanup ──────────────────────────────────────────────────────────────────
+rm -f "${DUMP_FILE}" "${ENCRYPTED_FILE}"
+
+echo "Backup complete: s3://${BACKUP_S3_BUCKET}/${S3_KEY}"

--- a/backend/src/database/entities/audit-log.entity.ts
+++ b/backend/src/database/entities/audit-log.entity.ts
@@ -17,10 +17,16 @@ export class AuditLog {
   entityId: string | null;
 
   @Column({ length: 20 })
-  action: string;
+  action: 'INSERT' | 'UPDATE' | 'DELETE';
 
-  @Column({ type: 'text', nullable: true })
-  changes: string | null;
+  @Column({ name: 'old_values', type: 'jsonb', nullable: true })
+  oldValues: Record<string, unknown> | null;
+
+  @Column({ name: 'new_values', type: 'jsonb', nullable: true })
+  newValues: Record<string, unknown> | null;
+
+  @Column({ name: 'user_id', nullable: true })
+  userId: string | null;
 
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;

--- a/backend/src/database/subscribers/audit.subscriber.ts
+++ b/backend/src/database/subscribers/audit.subscriber.ts
@@ -4,40 +4,79 @@ import {
   EventSubscriber,
   InsertEvent,
   UpdateEvent,
+  RemoveEvent,
 } from 'typeorm';
 import { Injectable } from '@nestjs/common';
 import { InjectDataSource } from '@nestjs/typeorm';
-import { TradeDeal } from '../../trade-deals/entities/trade-deal.entity';
 import { AuditLog } from '../entities/audit-log.entity';
+
+const SENSITIVE_FIELDS = new Set([
+  'password',
+  'passwordHash',
+  'password_hash',
+  'token',
+  'refreshToken',
+  'refresh_token',
+  'accessToken',
+  'access_token',
+  'secret',
+  'privateKey',
+  'private_key',
+]);
+
+function sanitize(obj: Record<string, unknown> | null | undefined): Record<string, unknown> | null {
+  if (!obj) return null;
+  return Object.fromEntries(
+    Object.entries(obj).filter(([key]) => !SENSITIVE_FIELDS.has(key)),
+  );
+}
 
 @Injectable()
 @EventSubscriber()
-export class AuditSubscriber implements EntitySubscriberInterface<TradeDeal> {
+export class AuditSubscriber implements EntitySubscriberInterface {
   constructor(@InjectDataSource() private readonly dataSource: DataSource) {
     dataSource.subscribers.push(this);
   }
 
-  listenTo() {
-    return TradeDeal;
+  private getUserId(event: any): string | null {
+    return (event.queryRunner?.data?.userId as string) ?? null;
   }
 
-  async afterInsert(event: InsertEvent<TradeDeal>): Promise<void> {
+  async afterInsert(event: InsertEvent<any>): Promise<void> {
+    const entity = event.entity as Record<string, unknown> | undefined;
     await event.manager.save(AuditLog, {
-      entityName: 'TradeDeal',
-      entityId: event.entity?.id ?? null,
-      action: 'INSERT',
-      changes: JSON.stringify(event.entity),
+      entityName: event.metadata.name,
+      entityId: entity?.['id'] ? String(entity['id']) : null,
+      action: 'INSERT' as const,
+      oldValues: null,
+      newValues: sanitize(entity ?? null),
+      userId: this.getUserId(event),
     });
   }
 
-  async afterUpdate(event: UpdateEvent<TradeDeal>): Promise<void> {
+  async afterUpdate(event: UpdateEvent<any>): Promise<void> {
+    const entity = event.entity as Record<string, unknown> | undefined;
+    const databaseEntity = event.databaseEntity as Record<string, unknown> | undefined;
     await event.manager.save(AuditLog, {
-      entityName: 'TradeDeal',
-      entityId: event.entity?.id ?? null,
-      action: 'UPDATE',
-      changes: JSON.stringify(
-        event.updatedColumns?.map((col) => col.propertyName) ?? [],
-      ),
+      entityName: event.metadata.name,
+      entityId: entity?.['id'] ? String(entity['id']) : null,
+      action: 'UPDATE' as const,
+      oldValues: sanitize(databaseEntity ?? null),
+      newValues: sanitize(entity ?? null),
+      userId: this.getUserId(event),
+    });
+  }
+
+  async afterRemove(event: RemoveEvent<any>): Promise<void> {
+    const entity = event.entity as Record<string, unknown> | undefined;
+    const databaseEntity = event.databaseEntity as Record<string, unknown> | undefined;
+    await event.manager.save(AuditLog, {
+      entityName: event.metadata.name,
+      entityId: entity?.['id'] ? String(entity['id']) : null,
+      action: 'DELETE' as const,
+      oldValues: sanitize(databaseEntity ?? entity ?? null),
+      newValues: null,
+      userId: this.getUserId(event),
     });
   }
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -8,6 +8,8 @@ import {
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 import { applySecurityHeaders } from './common/middleware/security-headers.middleware';
+import * as cookieParser from 'cookie-parser';
+import * as csrf from 'csurf';
 
 async function bootstrap() {
   // rawBody: true preserves the unparsed request buffer on req.rawBody,
@@ -15,6 +17,19 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule, { rawBody: true });
 
   app.use(applySecurityHeaders);
+
+  // Cookie parser is required by csurf
+  app.use(cookieParser());
+
+  // CSRF protection for cookie-based (session) endpoints.
+  // JWT-only routes are unaffected; the token is exposed via GET /csrf-token.
+  const csrfProtection = csrf({ cookie: { httpOnly: true, sameSite: 'strict' } });
+  app.use(csrfProtection);
+
+  // Expose CSRF token so clients can fetch it before mutating requests
+  app.use('/csrf-token', (req: any, res: any) => {
+    res.json({ csrfToken: req.csrfToken() });
+  });
 
   app.useGlobalPipes(
     new ValidationPipe({

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -15,6 +15,47 @@ const nextConfig = {
     NEXT_PUBLIC_API_URL:
       process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001',
   },
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          {
+            key: 'Content-Security-Policy',
+            value: [
+              "default-src 'self'",
+              "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+              "style-src 'self' 'unsafe-inline'",
+              "img-src 'self' data: blob:",
+              "font-src 'self'",
+              "connect-src 'self' https://horizon-testnet.stellar.org https://horizon.stellar.org",
+              "frame-ancestors 'none'",
+            ].join('; '),
+          },
+          {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=31536000; includeSubDomains; preload',
+          },
+          {
+            key: 'X-Content-Type-Options',
+            value: 'nosniff',
+          },
+          {
+            key: 'X-Frame-Options',
+            value: 'DENY',
+          },
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin',
+          },
+          {
+            key: 'Permissions-Policy',
+            value: 'camera=(), microphone=(), geolocation=()',
+          },
+        ],
+      },
+    ];
+  },
 };
 
 const withIntl = withNextIntl(nextConfig);


### PR DESCRIPTION
#399 - Add csurf middleware + cookie-parser to main.ts; expose GET /csrf-token #400 - Add CSP, HSTS, X-Content-Type-Options, Referrer-Policy, Permissions-Policy headers in next.config.js #401 - Add backend/scripts/backup.sh: pg_dump → AES-256 openssl encrypt → S3 upload #402 - Enhance AuditLog entity (oldValues, newValues, userId); make AuditSubscriber generic for all entities; exclude sensitive fields
closes #399 
closes #400 
closes #401 
closes #402 