### PR TITLE
[Security] Implement DNS rebinding, queue encryption, network policie…

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -22,6 +22,9 @@ STELLAR_PLATFORM_PUBLIC=your-stellar-public-key-here
 # Encryption Configuration
 ENCRYPTION_KEY=your-32-character-encryption-key-here # Required: 32-byte hex (generate with `openssl rand -hex 32`)
 
+# Queue Payload Encryption (falls back to ENCRYPTION_KEY if unset)
+QUEUE_ENCRYPTION_KEY= # 64-char hex — generate with: openssl rand -hex 32
+
 # IPFS/Storage Configuration (Optional)
 IPFS_GATEWAY=https://api.web3.storage
 IPFS_TOKEN=your-web3-storage-token
@@ -33,6 +36,7 @@ AWS_S3_BUCKET=your-s3-bucket-name
 # Server Configuration
 PORT=3001
 ALLOWED_ORIGINS=http://localhost:3000,http://localhost:3001
+ALLOWED_HOSTS=localhost,agri-fi.local,api.agri-fi.local # DNS rebinding protection — comma-separated whitelisted Host header values
 
 # Logging Configuration
 NODE_ENV=development
@@ -70,3 +74,8 @@ SOROBAN_DISTRIBUTOR_CONTRACT_ID=
 # USDC asset on Stellar (required for Soroban contract calls)
 USDC_ASSET_CODE=USDC
 USDC_ISSUER=GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
+
+# Document Digital Signature Verification
+# Comma-separated armored PGP public keys of trusted certifying authorities
+# (port authorities, inspection bodies, etc.). If unset, signature_asc is ignored.
+TRUSTED_AUTHORITY_KEYS=

--- a/backend/k8s/deployment.yaml
+++ b/backend/k8s/deployment.yaml
@@ -65,3 +65,4 @@ data:
   STELLAR_NETWORK: "testnet"
   STELLAR_HORIZON_URL: "https://horizon-testnet.stellar.org"
   ALLOWED_ORIGINS: "http://agri-fi-frontend"
+  ALLOWED_HOSTS: "agri-fi.local,api.agri-fi.local"

--- a/backend/k8s/ingress.yaml
+++ b/backend/k8s/ingress.yaml
@@ -1,0 +1,35 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: agri-fi-ingress
+  labels:
+    app: agri-fi
+spec:
+  rules:
+    - host: agri-fi.local
+      http:
+        paths:
+          - path: /api/
+            pathType: Prefix
+            backend:
+              service:
+                name: agri-fi-backend
+                port:
+                  number: 80
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: agri-fi-frontend
+                port:
+                  number: 80
+    - host: api.agri-fi.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: agri-fi-backend
+                port:
+                  number: 80

--- a/backend/k8s/network-policy.yaml
+++ b/backend/k8s/network-policy.yaml
@@ -1,0 +1,45 @@
+# Restrict Postgres ingress to backend pods only and block all external egress
+# from the Postgres pod. Linux conntrack allows TCP responses to established
+# inbound connections even with egress: [], so queries work correctly.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: postgres-isolation
+spec:
+  podSelector:
+    matchLabels:
+      app: postgres
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: agri-fi-backend
+      ports:
+        - protocol: TCP
+          port: 5432
+  egress: []
+---
+# Restrict RabbitMQ ingress to backend pods only and block all external egress.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: rabbitmq-isolation
+spec:
+  podSelector:
+    matchLabels:
+      app: rabbitmq
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: agri-fi-backend
+      ports:
+        - protocol: TCP
+          port: 5672
+  egress: []

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -37,6 +37,7 @@
         "nestjs-cls": "^6.2.0",
         "nestjs-pino": "^4.6.1",
         "nodemailer": "^8.0.6",
+        "openpgp": "^4.10.11",
         "passport": "^0.6.0",
         "passport-jwt": "^4.0.1",
         "passport-local": "^1.0.0",
@@ -1149,6 +1150,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2525,6 +2527,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.4.22.tgz",
       "integrity": "sha512-fxJ4v85nDHaqT1PmfNCQ37b/jcv2OojtXTaK1P2uAXhzLf9qq6WNUOFvxBrV4fhQek1EQoT1o9oj5xAZmv3NRw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-type": "20.4.1",
         "iterare": "1.2.1",
@@ -2571,6 +2574,7 @@
       "integrity": "sha512-6IX9+VwjiKtCjx+mXVPncpkQ5ZjKfmssOZPFexmT+6T9H9wZ3svpYACAo7+9e7Nr9DZSoRZw3pffkJP7Z0UjaA==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nuxtjs/opencollective": "0.3.2",
         "fast-safe-stringify": "2.1.1",
@@ -2641,6 +2645,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/microservices/-/microservices-10.4.22.tgz",
       "integrity": "sha512-9Oxc0jQuppGLaQv5yaB2tVS2rAZzZ9NqDS1A4UlDLiYwJB7M6e89G6tmyOQjGjPwgoXPxQS4Vg2voSiKiED2gw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "iterare": "1.2.1",
         "tslib": "2.8.1"
@@ -2709,6 +2714,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.4.22.tgz",
       "integrity": "sha512-ySSq7Py/DFozzZdNDH67m/vHoeVdphDniWBnl6q5QVoXldDdrZIHLXLRMPayTDh5A95nt7jjJzmD4qpTbNQ6tA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "body-parser": "1.20.4",
         "cors": "2.8.5",
@@ -2730,6 +2736,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-10.4.22.tgz",
       "integrity": "sha512-xxGw3R0Ihr51/Omq23z3//bKmCXyVKaikxbH0/pkwqMsQrxkUv9NabNUZ22b4Jnlwwi02X+zlwo8GRa9u8oV9g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "socket.io": "4.8.1",
         "tslib": "2.8.1"
@@ -2946,6 +2953,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/typeorm/-/typeorm-10.0.2.tgz",
       "integrity": "sha512-H738bJyydK4SQkRCTeh1aFBxoO1E9xdL/HaLGThwrqN95os5mEyAtK7BLADOS+vldP4jDZ2VQPLj4epWwRqCeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "uuid": "9.0.1"
       },
@@ -2962,6 +2970,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-10.4.22.tgz",
       "integrity": "sha512-OLd4i0Faq7vgdtB5vVUrJ54hWEtcXy9poJ6n7kbbh/5ms+KffUl+wwGsbe7uSXLrkoyI8xXU6fZPkFArI+XiRg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "iterare": "1.2.1",
         "object-hash": "3.0.0",
@@ -3799,6 +3808,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3820,6 +3830,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
       "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -3835,6 +3846,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
       "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.214.0",
         "import-in-the-middle": "^3.0.0",
@@ -3868,6 +3880,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
       "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.7.1",
         "@opentelemetry/resources": "2.7.1",
@@ -3885,6 +3898,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
       "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -3945,6 +3959,7 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.12.1.tgz",
       "integrity": "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -5491,6 +5506,7 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -5961,6 +5977,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6041,6 +6058,7 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -6109,6 +6127,7 @@
       "resolved": "https://registry.npmjs.org/amqp-connection-manager/-/amqp-connection-manager-4.1.15.tgz",
       "integrity": "sha512-YGi8MuO2K4u0qC4b1qAKVIK8CdBJF+PpEZpHKxmrL3x61pU1sAb2SHzQl7ypoqr6oECIfVqtG9DGdOZxaUq1Wg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "promise-breaker": "^6.0.0"
       },
@@ -6125,6 +6144,7 @@
       "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.10.9.tgz",
       "integrity": "sha512-jwSftI4QjS3mizvnSnOrPGYiUnm1vI2OP1iXeOUz5pb74Ua0nbf6nPyyTzuiCLEE3fMpaJORXh2K/TQ08H5xGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "buffer-more-ints": "~1.0.0",
         "url-parse": "~1.5.10"
@@ -6312,6 +6332,18 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
     },
     "node_modules/astral-regex": {
       "version": "2.0.0",
@@ -6680,6 +6712,12 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
       "version": "1.20.4",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
@@ -6816,6 +6854,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7141,13 +7180,15 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/class-validator": {
       "version": "0.14.4",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.4.tgz",
       "integrity": "sha512-AwNusCCam51q703dW82x95tOqQp6oC9HNUl724KxJJOfnKscI8dOloXFgyez7LbTTKWuRBA37FScqVbJEoq8Yw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -8134,6 +8175,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -8190,6 +8232,7 @@
       "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -8570,6 +8613,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -9436,7 +9480,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/graphemer": {
@@ -9814,7 +9857,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -10267,6 +10309,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -11481,6 +11524,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -11710,6 +11759,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-localstorage": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-1.3.1.tgz",
+      "integrity": "sha512-NMWCSWWc6JbHT5PyWlNT2i8r7PgGYXVntmKawY83k/M0UJScZ5jirb61TLnqKwd815DfBQu+lR3sRw08SPzIaQ==",
+      "dependencies": {
+        "write-file-atomic": "^1.1.4"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/node-localstorage/node_modules/write-file-atomic": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+      "integrity": "sha512-SdrHoC/yVBPpV0Xq/mUZQIpW2sWXAShb/V4pomcJXh92RuaO+f3UTWItiR3Px+pLnV2PvC2/bfn5cwr5X6Vfxw==",
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "slide": "^1.1.5"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
@@ -11860,6 +11931,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openpgp": {
+      "version": "4.10.11",
+      "resolved": "https://registry.npmjs.org/openpgp/-/openpgp-4.10.11.tgz",
+      "integrity": "sha512-ec8m6xkuBqTaSSoNEr7CK0AepeVvKkgvMxs0KVAtEHlFDd1fA93Q+jYls6vRfrZDl0UEAEmcvRUa4W8VuGey2w==",
+      "deprecated": "This version is deprecated and will no longer receive security patches. Please refer to https://github.com/openpgpjs/openpgpjs/wiki/Updating-from-previous-versions for details on how to upgrade to a newer supported version.",
+      "license": "LGPL-3.0+",
+      "dependencies": {
+        "asn1.js": "^5.0.0",
+        "node-fetch": "^2.1.2",
+        "node-localstorage": "~1.3.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/optionator": {
@@ -12021,6 +12107,7 @@
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.6.0.tgz",
       "integrity": "sha512-0fe+p3ZnrWRW74fe8+SvCyf4a3Pb2/h7gFkQ8yTJpAO50gDzlfjZUZTO1k5Eg9kUct22OxHLqDZoKUWRHOh9ug==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -12172,6 +12259,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -12281,6 +12369,7 @@
       "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
       "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@pinojs/redact": "^0.4.0",
         "atomic-sleep": "^1.0.0",
@@ -12312,6 +12401,7 @@
       "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-11.0.0.tgz",
       "integrity": "sha512-wqg5XIAGRRIWtTk8qPGxkbrfiwEWz1lgedVLvhLALudKXvg1/L2lTFgTGPJ4Z2e3qcRmxoFxDuSdMdMGNM6I1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "get-caller-file": "^2.0.5",
         "pino": "^10.0.0",
@@ -12458,6 +12548,7 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -12530,6 +12621,7 @@
       "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
       "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/api": "^1.4.0",
         "tdigest": "^0.1.1"
@@ -12766,6 +12858,7 @@
       "resolved": "https://registry.npmjs.org/redis/-/redis-5.12.1.tgz",
       "integrity": "sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@redis/bloom": "5.12.1",
         "@redis/client": "5.12.1",
@@ -12781,7 +12874,8 @@
       "version": "0.1.14",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.14.tgz",
       "integrity": "sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/repeat-string": {
       "version": "1.6.1",
@@ -13039,6 +13133,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -13357,6 +13452,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==",
+      "license": "ISC",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/socket.io": {
@@ -14107,6 +14211,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -14461,6 +14566,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -14639,6 +14745,7 @@
       "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.28.tgz",
       "integrity": "sha512-6GH7wXhtfq2D33ZuRXYwIsl/qM5685WZcODZb7noOOcRMteM9KF2x2ap3H0EBjnSV0VO4gNAfJT5Ukp0PkOlvg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^4.2.0",
@@ -14865,6 +14972,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15107,6 +15215,7 @@
       "integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",

--- a/backend/package.json
+++ b/backend/package.json
@@ -52,6 +52,7 @@
     "nestjs-cls": "^6.2.0",
     "nestjs-pino": "^4.6.1",
     "nodemailer": "^8.0.6",
+    "openpgp": "^4.10.11",
     "passport": "^0.6.0",
     "passport-jwt": "^4.0.1",
     "passport-local": "^1.0.0",

--- a/backend/src/database/migrations/1765000000000-AddSignatureVerifiedToDocuments.ts
+++ b/backend/src/database/migrations/1765000000000-AddSignatureVerifiedToDocuments.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSignatureVerifiedToDocuments1765000000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "documents" ADD COLUMN IF NOT EXISTS "signature_verified" boolean NOT NULL DEFAULT false`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "documents" DROP COLUMN IF EXISTS "signature_verified"`,
+    );
+  }
+}

--- a/backend/src/documents/documents.controller.ts
+++ b/backend/src/documents/documents.controller.ts
@@ -59,6 +59,11 @@ export class DocumentsController {
           type: 'string',
           example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
         },
+        signature_asc: {
+          type: 'string',
+          description:
+            'Optional detached PGP/GnuPG armored signature of the file, issued by a trusted certifying authority',
+        },
       },
     },
   })
@@ -75,7 +80,8 @@ export class DocumentsController {
   @ApiResponse({ status: 429, description: 'Too Many Requests – IPFS proxy limit is 20 per minute' })
   async uploadDocument(
     @UploadedFile() file: Express.Multer.File,
-    @Body() body: { doc_type: string; trade_deal_id: string },
+    @Body()
+    body: { doc_type: string; trade_deal_id: string; signature_asc?: string },
     @Request() req: AuthRequest,
   ) {
     if (!file) throw new BadRequestException('File is required');
@@ -102,6 +108,7 @@ export class DocumentsController {
       docType: body.doc_type,
       tradeDealId: body.trade_deal_id,
       userId: req.user.id,
+      signatureAsc: body.signature_asc,
     });
 
     this.ipfsCache.set(contentKey, result);

--- a/backend/src/documents/documents.service.ts
+++ b/backend/src/documents/documents.service.ts
@@ -6,6 +6,8 @@ import { ConfigService } from '@nestjs/config';
 import { createHash } from 'crypto';
 import { buildDocumentMemo } from '../stellar/anchor-memo';
 import { isValidIpfsCid } from './ipfs-cid';
+// openpgp@4 is CommonJS-compatible; openpgp@5+ is ESM-only and would break here.
+import * as openpgp from 'openpgp';
 
 @Injectable()
 export class DocumentsService {
@@ -21,11 +23,13 @@ export class DocumentsService {
     docType,
     tradeDealId,
     userId,
+    signatureAsc,
   }: {
     file: Express.Multer.File;
     docType: string;
     tradeDealId: string;
     userId: string;
+    signatureAsc?: string;
   }) {
     // 1. Upload (IPFS → S3 fallback handled internally)
     const { hash, url } = await this.storageService.upload(
@@ -48,7 +52,14 @@ export class DocumentsService {
       signerSecret,
     );
 
-    // 3. Persist using existing logic (VERY IMPORTANT)
+    // 3. Verify detached GnuPG signature if one was supplied (max 4 KB to
+    //    prevent CPU exhaustion from oversized armored payloads).
+    let signatureVerified = false;
+    if (signatureAsc && signatureAsc.length <= 4096) {
+      signatureVerified = await this.verifySignature(file.buffer, signatureAsc);
+    }
+
+    // 4. Persist using existing logic (VERY IMPORTANT)
     return this.tradeDealsService.addDocument({
       tradeDealId,
       uploaderId: userId,
@@ -58,6 +69,37 @@ export class DocumentsService {
       stellarTxId,
       fileSizeBytes: file.size,
       memoText: memo,
+      signatureVerified,
     });
+  }
+
+  private async verifySignature(
+    fileBuffer: Buffer,
+    armoredSig: string,
+  ): Promise<boolean> {
+    const trustedKeysRaw = this.config.get<string>('TRUSTED_AUTHORITY_KEYS', '');
+    if (!trustedKeysRaw) return false;
+    try {
+      const publicKeys: openpgp.key.Key[] = [];
+      for (const raw of trustedKeysRaw.split(',')) {
+        const trimmed = raw.trim();
+        if (!trimmed) continue;
+        const { keys, err } = await openpgp.key.readArmored(trimmed);
+        if (err && err.length) continue;
+        publicKeys.push(...keys);
+      }
+      if (!publicKeys.length) return false;
+
+      const message = openpgp.message.fromBinary(new Uint8Array(fileBuffer));
+      const signature = await openpgp.signature.readArmored(armoredSig);
+      const result = await openpgp.verify({ message, signature, publicKeys });
+
+      const validities = await Promise.all(
+        result.signatures.map((s: any) => s.valid),
+      );
+      return validities.some((v: boolean | null) => v === true);
+    } catch {
+      return false;
+    }
   }
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -16,6 +16,25 @@ async function bootstrap() {
 
   app.getHttpAdapter().getInstance().disable('x-powered-by');
 
+  // DNS rebinding protection: reject requests whose Host header does not match
+  // a known domain. /health is exempted so kubelet liveness/readiness probes
+  // (which use the pod IP as Host) never get blocked.
+  const allowedHosts = (process.env.ALLOWED_HOSTS ?? 'localhost')
+    .split(',')
+    .map((h) => h.trim().toLowerCase());
+
+  app.use((req: any, res: any, next: () => void) => {
+    if (req.path === '/health' || req.path === '/v1/health') {
+      return next();
+    }
+    const host = (req.headers['host'] ?? '').split(':')[0].toLowerCase();
+    if (!allowedHosts.includes(host)) {
+      res.status(421).end('Misdirected Request');
+      return;
+    }
+    next();
+  });
+
   app.use(applySecurityHeaders);
 
   app.useGlobalPipes(

--- a/backend/src/queue/queue.crypto.ts
+++ b/backend/src/queue/queue.crypto.ts
@@ -1,0 +1,42 @@
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
+
+const ALGORITHM = 'aes-256-cbc';
+
+function getKey(): Buffer {
+  const hex = process.env.QUEUE_ENCRYPTION_KEY ?? process.env.ENCRYPTION_KEY;
+  if (!hex || hex.length !== 64) {
+    throw new Error(
+      'QUEUE_ENCRYPTION_KEY must be a 64-character hex string (32 bytes). ' +
+        'Generate with: openssl rand -hex 32',
+    );
+  }
+  return Buffer.from(hex, 'hex');
+}
+
+export function encryptPayload(data: unknown): string {
+  const iv = randomBytes(16);
+  const cipher = createCipheriv(ALGORITHM, getKey(), iv);
+  const enc = Buffer.concat([
+    cipher.update(JSON.stringify(data), 'utf8'),
+    cipher.final(),
+  ]);
+  return `v1:${iv.toString('hex')}:${enc.toString('hex')}`;
+}
+
+export function decryptPayload<T = unknown>(ciphertext: string): T {
+  const parts = ciphertext.split(':');
+  if (parts.length !== 3 || parts[0] !== 'v1') {
+    throw new Error('Invalid ciphertext format — expected v1:<iv>:<data>');
+  }
+  const [, ivHex, encHex] = parts;
+  const decipher = createDecipheriv(
+    ALGORITHM,
+    getKey(),
+    Buffer.from(ivHex, 'hex'),
+  );
+  const dec = Buffer.concat([
+    decipher.update(Buffer.from(encHex, 'hex')),
+    decipher.final(),
+  ]);
+  return JSON.parse(dec.toString('utf8')) as T;
+}

--- a/backend/src/queue/queue.processor.ts
+++ b/backend/src/queue/queue.processor.ts
@@ -22,6 +22,7 @@ import {
   DEFAULT_QUEUE_MAX_RETRIES,
   getExponentialBackoffDelayMs,
 } from './retry-policy';
+import { decryptPayload } from './queue.crypto';
 
 @Controller()
 export class QueueProcessor {
@@ -48,11 +49,39 @@ export class QueueProcessor {
     }
   }
 
+  private unwrap<T>(
+    encrypted: string,
+    pattern: string,
+    channel: any,
+    msg: any,
+  ): T | null {
+    try {
+      return decryptPayload<T>(encrypted);
+    } catch (err: any) {
+      this.logger.error(
+        { event: pattern, error: err.message },
+        `${pattern} decryption failed — nacking message`,
+      );
+      channel.nack(msg, false, false);
+      return null;
+    }
+  }
+
   @EventPattern('deal.publish')
   async handleDealPublish(
-    @Payload() data: DealPublishPayload,
+    @Payload() encrypted: string,
     @Ctx() context: RmqContext,
   ) {
+    const channel = context.getChannelRef();
+    const originalMsg = context.getMessage();
+    const data = this.unwrap<DealPublishPayload>(
+      encrypted,
+      'deal.publish',
+      channel,
+      originalMsg,
+    );
+    if (!data) return;
+
     this.setCorrelationId(data);
     this.logger.info(
       { dealId: data.dealId },
@@ -114,16 +143,24 @@ export class QueueProcessor {
     }
 
     // Acknowledge the message
-    const channel = context.getChannelRef();
-    const originalMsg = context.getMessage();
     channel.ack(originalMsg);
   }
 
   @EventPattern('investment.fund')
   async handleInvestmentFund(
-    @Payload() data: InvestmentFundPayload,
+    @Payload() encrypted: string,
     @Ctx() context: RmqContext,
   ) {
+    const channel = context.getChannelRef();
+    const originalMsg = context.getMessage();
+    const data = this.unwrap<InvestmentFundPayload>(
+      encrypted,
+      'investment.fund',
+      channel,
+      originalMsg,
+    );
+    if (!data) return;
+
     this.setCorrelationId(data);
     this.logger.info(
       { investmentId: data.investmentId },
@@ -132,8 +169,6 @@ export class QueueProcessor {
 
     let attempt = 0;
     let lastError: Error | null = null;
-    const channel = context.getChannelRef();
-    const originalMsg = context.getMessage();
 
     while (attempt < DEFAULT_QUEUE_MAX_RETRIES) {
       try {
@@ -211,9 +246,19 @@ export class QueueProcessor {
 
   @EventPattern('deal.funded')
   async handleDealFunded(
-    @Payload() data: DealFundedPayload,
+    @Payload() encrypted: string,
     @Ctx() context: RmqContext,
   ) {
+    const channel = context.getChannelRef();
+    const originalMsg = context.getMessage();
+    const data = this.unwrap<DealFundedPayload>(
+      encrypted,
+      'deal.funded',
+      channel,
+      originalMsg,
+    );
+    if (!data) return;
+
     this.setCorrelationId(data);
     this.logger.info(
       { tradeDealId: data.tradeDealId },
@@ -236,15 +281,24 @@ export class QueueProcessor {
       );
     }
 
-    const channel = context.getChannelRef();
-    channel.ack(context.getMessage());
+    channel.ack(originalMsg);
   }
 
   @EventPattern('email.notification')
   async handleEmailNotification(
-    @Payload() data: any,
+    @Payload() encrypted: string,
     @Ctx() context: RmqContext,
   ) {
+    const channel = context.getChannelRef();
+    const originalMsg = context.getMessage();
+    const data = this.unwrap<any>(
+      encrypted,
+      'email.notification',
+      channel,
+      originalMsg,
+    );
+    if (!data) return;
+
     this.setCorrelationId(data);
     this.logger.info(
       { type: data.type },
@@ -306,15 +360,24 @@ export class QueueProcessor {
       );
     }
 
-    const channel = context.getChannelRef();
-    channel.ack(context.getMessage());
+    channel.ack(originalMsg);
   }
 
   @EventPattern('deal.cleanup')
   async handleDealCleanup(
-    @Payload() data: DealCleanupPayload,
+    @Payload() encrypted: string,
     @Ctx() context: RmqContext,
   ) {
+    const channel = context.getChannelRef();
+    const originalMsg = context.getMessage();
+    const data = this.unwrap<DealCleanupPayload>(
+      encrypted,
+      'deal.cleanup',
+      channel,
+      originalMsg,
+    );
+    if (!data) return;
+
     this.setCorrelationId(data);
     this.logger.info(
       { dealId: data.tradeDealId },
@@ -325,8 +388,7 @@ export class QueueProcessor {
       const deal = await this.tradeDealsService.findOne(data.tradeDealId);
       if (!deal) {
         this.logger.warn(`Deal ${data.tradeDealId} not found for cleanup`);
-        const channel = context.getChannelRef();
-        channel.ack(context.getMessage());
+        channel.ack(originalMsg);
         return;
       }
 
@@ -389,8 +451,7 @@ export class QueueProcessor {
       // We still ack the message, it's a best-effort cleanup
     }
 
-    const channel = context.getChannelRef();
-    channel.ack(context.getMessage());
+    channel.ack(originalMsg);
   }
 
   // ── Private helpers ─────────────────────────────────────────────────────────

--- a/backend/src/queue/queue.service.ts
+++ b/backend/src/queue/queue.service.ts
@@ -3,6 +3,7 @@ import { ClientProxy } from '@nestjs/microservices';
 import { PinoLogger } from 'nestjs-pino';
 import { ClsService } from 'nestjs-cls'; // Added for safe context access
 import { QUEUE_SERVICE } from './queue.constants';
+import { encryptPayload } from './queue.crypto';
 
 export interface BasePayload {
   correlationId?: string;
@@ -62,7 +63,7 @@ export class QueueService {
 
   public async emit(pattern: string, data: unknown): Promise<void> {
     try {
-      this.client.emit(pattern, data);
+      this.client.emit(pattern, encryptPayload(data));
       this.logger.info({ event: pattern }, `Emitted event: ${pattern}`);
     } catch (err) {
       this.logger.error(

--- a/backend/src/trade-deals/entities/document.entity.ts
+++ b/backend/src/trade-deals/entities/document.entity.ts
@@ -41,6 +41,9 @@ export class Document {
   @Column({ name: 'memo_text', nullable: true })
   memoText: string | null;
 
+  @Column({ name: 'signature_verified', default: false })
+  signatureVerified: boolean;
+
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
 

--- a/backend/src/trade-deals/trade-deals.service.ts
+++ b/backend/src/trade-deals/trade-deals.service.ts
@@ -37,6 +37,7 @@ export interface AddDocumentDto {
   stellarTxId?: string | null;
   fileSizeBytes?: number;
   memoText?: string | null;
+  signatureVerified?: boolean;
 }
 
 @Injectable()
@@ -368,6 +369,7 @@ export class TradeDealsService {
       storageUrl: dto.storageUrl,
       stellarTxId: dto.stellarTxId ?? null,
       memoText: dto.memoText ?? null,
+      signatureVerified: dto.signatureVerified ?? false,
     });
 
     return this.documentRepo.save(doc);

--- a/devops/nginx/nginx.conf
+++ b/devops/nginx/nginx.conf
@@ -55,6 +55,15 @@ http {
         keepalive 32;
     }
 
+    # ── DNS rebinding protection: drop requests with unknown Host headers ───────
+    # Without this block Nginx would serve the first named vhost for any Host,
+    # which enables DNS rebinding attacks.
+    server {
+        listen 80 default_server;
+        server_name _;
+        return 444;
+    }
+
     # ── API Server Block (api.agri-fi.local) ──────────────────────────────────
     server {
         listen 80;


### PR DESCRIPTION
 ## What

  Resolves four security hardening issues:

  - **#423 DNS Rebinding** – Added `ALLOWED_HOSTS` Host-header whitelist middleware in `main.ts`
  (HTTP 421 for unknown hosts, `/health` exempted for K8s probes), a `default_server` catch-all in
  `nginx.conf` returning 444, and a new Kubernetes Ingress scoped to known hostnames.
  - **#422 RabbitMQ Encryption** – All queue payloads are AES-256-CBC encrypted before publish
  (`v1:<iv>:<ciphertext>` format) and decrypted in all six consumer handlers. Decryption failure
  nacks the message to a dead-letter queue instead of silently discarding it. Key validated as 32
  bytes at startup.
  - **#419 Network Policies** – New `network-policy.yaml` restricts Postgres and RabbitMQ ingress
  to backend pods only (pod-level selector, not namespace-level) and blocks all new outbound
  connections from those pods.
  - **#418 Document Signatures** – Documents can be submitted with a detached PGP/GnuPG armored
  signature. Signatures are verified against whitelisted authority public keys in
  `TRUSTED_AUTHORITY_KEYS`; documents are marked `signatureVerified: true` automatically on
  success. Includes TypeORM migration for the new column.

  ## Closes

  Closes #423, closes #422, closes #419, closes #418

  ## Changes

  - `backend/src/queue/queue.crypto.ts` — new AES-256-CBC helpers with startup key validation

  Closes #423, closes #422, closes #419, closes #418