### PR TITLE
feat: Horizon timeout, SEP-0001 toml, stellar wallet guard, SEP-38 quote service

### DIFF
--- a/backend/src/auth/guards/stellar-wallet.guard.ts
+++ b/backend/src/auth/guards/stellar-wallet.guard.ts
@@ -1,0 +1,70 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Keypair } from '@stellar/stellar-sdk';
+import { Request } from 'express';
+
+const MAX_TIMESTAMP_DRIFT_MS = 5 * 60 * 1000; // 5 minutes
+
+@Injectable()
+export class StellarWalletGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<Request>();
+
+    const account = request.headers['x-stellar-account'] as string | undefined;
+    const signatureB64 = request.headers['x-stellar-signature'] as string | undefined;
+    const timestamp = request.headers['x-stellar-timestamp'] as string | undefined;
+
+    if (!account || !signatureB64 || !timestamp) {
+      throw new UnauthorizedException({
+        code: 'STELLAR_AUTH_MISSING',
+        message:
+          'x-stellar-account, x-stellar-signature, and x-stellar-timestamp headers are required.',
+      });
+    }
+
+    const ts = Number(timestamp);
+    if (Number.isNaN(ts) || Math.abs(Date.now() - ts) > MAX_TIMESTAMP_DRIFT_MS) {
+      throw new UnauthorizedException({
+        code: 'STELLAR_AUTH_REPLAY',
+        message: 'Timestamp is missing, invalid, or outside the 5-minute replay window.',
+      });
+    }
+
+    let keypair: Keypair;
+    try {
+      keypair = Keypair.fromPublicKey(account);
+    } catch {
+      throw new UnauthorizedException({
+        code: 'STELLAR_AUTH_INVALID_KEY',
+        message: 'x-stellar-account is not a valid Stellar public key.',
+      });
+    }
+
+    let signatureBytes: Buffer;
+    try {
+      signatureBytes = Buffer.from(signatureB64, 'base64');
+    } catch {
+      throw new UnauthorizedException({
+        code: 'STELLAR_AUTH_INVALID_SIG',
+        message: 'x-stellar-signature must be a valid base64-encoded string.',
+      });
+    }
+
+    const message = Buffer.from(`${account}:${timestamp}`);
+    const valid = keypair.verify(message, signatureBytes);
+
+    if (!valid) {
+      throw new UnauthorizedException({
+        code: 'STELLAR_AUTH_SIG_MISMATCH',
+        message: 'Signature verification failed.',
+      });
+    }
+
+    (request as Request & { stellarAccount: string }).stellarAccount = account;
+    return true;
+  }
+}

--- a/backend/src/stellar/sep38.service.ts
+++ b/backend/src/stellar/sep38.service.ts
@@ -1,0 +1,113 @@
+import { Injectable, BadRequestException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PinoLogger } from 'nestjs-pino';
+
+export interface Sep38QuoteRequest {
+  sell_asset: string;
+  buy_asset: string;
+  sell_amount?: string;
+  buy_amount?: string;
+}
+
+export interface Sep38QuoteResponse {
+  id: string;
+  expires_at: string;
+  price: string;
+  sell_asset: string;
+  buy_asset: string;
+  sell_amount: string;
+  buy_amount: string;
+  fee: {
+    total: string;
+    asset: string;
+  };
+}
+
+const QUOTE_TTL_SECONDS = 60;
+const BPS_DIVISOR = 10_000;
+
+@Injectable()
+export class Sep38Service {
+  private readonly platformFeeBps: number;
+  private readonly usdcIssuer: string;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly logger: PinoLogger,
+  ) {
+    this.logger.setContext(Sep38Service.name);
+    this.platformFeeBps = this.config.get<number>('SEP38_FEE_BPS', 30);
+    this.usdcIssuer = this.config.get<string>(
+      'USDC_ISSUER',
+      'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+    );
+  }
+
+  async getQuote(req: Sep38QuoteRequest): Promise<Sep38QuoteResponse> {
+    const { sell_asset, buy_asset, sell_amount, buy_amount } = req;
+
+    if (!sell_asset || !buy_asset) {
+      throw new BadRequestException('sell_asset and buy_asset are required.');
+    }
+    if ((!sell_amount && !buy_amount) || (sell_amount && buy_amount)) {
+      throw new BadRequestException(
+        'Provide exactly one of sell_amount or buy_amount.',
+      );
+    }
+
+    const price = await this.fetchPrice(sell_asset, buy_asset);
+
+    let sellAmt: number;
+    let buyAmt: number;
+
+    if (sell_amount) {
+      sellAmt = parseFloat(sell_amount);
+      if (Number.isNaN(sellAmt) || sellAmt <= 0) {
+        throw new BadRequestException('sell_amount must be a positive number.');
+      }
+      buyAmt = sellAmt * price;
+    } else {
+      buyAmt = parseFloat(buy_amount!);
+      if (Number.isNaN(buyAmt) || buyAmt <= 0) {
+        throw new BadRequestException('buy_amount must be a positive number.');
+      }
+      sellAmt = buyAmt / price;
+    }
+
+    const feeAmt = (sellAmt * this.platformFeeBps) / BPS_DIVISOR;
+    const netBuyAmt = buyAmt - (feeAmt * price);
+
+    const expiresAt = new Date(Date.now() + QUOTE_TTL_SECONDS * 1000).toISOString();
+    const quoteId = `quote_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+
+    const quote: Sep38QuoteResponse = {
+      id: quoteId,
+      expires_at: expiresAt,
+      price: price.toFixed(7),
+      sell_asset,
+      buy_asset,
+      sell_amount: sellAmt.toFixed(7),
+      buy_amount: Math.max(0, netBuyAmt).toFixed(7),
+      fee: {
+        total: feeAmt.toFixed(7),
+        asset: sell_asset,
+      },
+    };
+
+    this.logger.info({ quoteId, sell_asset, buy_asset, price }, 'SEP-38 quote issued');
+    return quote;
+  }
+
+  private async fetchPrice(sellAsset: string, buyAsset: string): Promise<number> {
+    const xlmUsdcPair =
+      (sellAsset.startsWith('native') && buyAsset.startsWith('USDC')) ||
+      (buyAsset.startsWith('native') && sellAsset.startsWith('USDC'));
+
+    if (xlmUsdcPair) {
+      return this.config.get<number>('SEP38_XLM_USDC_RATE', 0.1);
+    }
+
+    this.logger.warn({ sellAsset, buyAsset }, 'Unsupported asset pair — returning 1:1 price');
+    return 1;
+  }
+}

--- a/backend/src/stellar/stellar.service.ts
+++ b/backend/src/stellar/stellar.service.ts
@@ -46,7 +46,7 @@ export class StellarService {
     );
     const network = config.get<string>('STELLAR_NETWORK', 'testnet');
 
-    this.server = new Horizon.Server(horizonUrl);
+    this.server = new Horizon.Server(horizonUrl, { timeout: 30000 });
     this.networkPassphrase =
       network === 'mainnet' ? Networks.PUBLIC : Networks.TESTNET;
 

--- a/frontend/public/.well-known/stellar.toml
+++ b/frontend/public/.well-known/stellar.toml
@@ -1,0 +1,38 @@
+# Agri-fi Stellar SEP-0001 Configuration
+# See: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md
+
+NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
+FEDERATION_SERVER="https://agri-fi.io/federation"
+AUTH_SERVER="https://agri-fi.io/auth"
+TRANSFER_SERVER="https://agri-fi.io/transfer"
+TRANSFER_SERVER_SEP0024="https://agri-fi.io/sep24"
+KYC_SERVER="https://agri-fi.io/kyc"
+WEB_AUTH_ENDPOINT="https://agri-fi.io/auth"
+
+[DOCUMENTATION]
+ORG_NAME="Agri-fi"
+ORG_URL="https://agri-fi.io"
+ORG_DESCRIPTION="Decentralised agricultural finance platform built on Stellar"
+ORG_GITHUB="https://github.com/Agri-fund/agri-fi"
+
+[[PRINCIPALS]]
+name="Agri-fi Team"
+email="team@agri-fi.io"
+
+[[CURRENCIES]]
+code="USDC"
+issuer="GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+display_decimals=6
+name="USD Coin"
+desc="Circle USDC on Stellar testnet"
+is_asset_anchored=true
+anchor_asset_type="fiat"
+anchor_asset="USD"
+status="test"
+
+[[VALIDATORS]]
+ALIAS="agri-fi-testnet"
+DISPLAY_NAME="Agri-fi Testnet Validator"
+HOST="validator.agri-fi.io:11625"
+PUBLIC_KEY="GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGWKX2ZVBFGCNX5J3MHAQX"
+HISTORY="https://validator.agri-fi.io/history"


### PR DESCRIPTION
## Summary

Closes #367
Closes #365
Closes #364
Closes #363

## Changes

### #367 — Fix Horizon Server connection timeout
Added `{ timeout: 30000 }` option to `Horizon.Server` constructor in `stellar.service.ts`. Without this, requests to Horizon can hang indefinitely under network degradation; the 30-second cap ensures `submitWithRetry` can cycle its backoff loop properly.

### #365 — Add SEP-0001 stellar.toml
Created `frontend/public/.well-known/stellar.toml` with full SEP-0001 metadata: `NETWORK_PASSPHRASE`, federation/auth/transfer server URLs, `[DOCUMENTATION]`, `[[PRINCIPALS]]`, `[[CURRENCIES]]` (USDC), and `[[VALIDATORS]]`. Browsers serving the Next.js frontend will expose this at `/.well-known/stellar.toml` automatically.

### #364 — StellarWalletGuard (NestJS)
New guard at `backend/src/auth/guards/stellar-wallet.guard.ts`. Reads `x-stellar-account`, `x-stellar-signature` (base64 keypair signature over `<account>:<timestamp>`), and `x-stellar-timestamp` from request headers. Validates:
- All three headers present
- Timestamp within 5-minute replay window
- Public key is a valid Stellar address
- Signature verified with `Keypair.verify()`

Attaches `stellarAccount` to the request on success; throws `401 UnauthorizedException` with a typed `code` on any failure.

### #363 — Sep38Service (SEP-38 quote server)
New service at `backend/src/stellar/sep38.service.ts`. Exposes `getQuote(req)` which:
- Accepts `sell_asset` / `buy_asset` + exactly one of `sell_amount` / `buy_amount`
- Fetches price via internal `fetchPrice()` (XLM↔USDC uses `SEP38_XLM_USDC_RATE` env var; other pairs default to 1:1 with a warning)
- Deducts platform fee (`SEP38_FEE_BPS`, default 30 bps)
- Returns a `Sep38QuoteResponse` with a unique `id`, `expires_at` (60 seconds from now), `price`, amounts, and `fee` breakdown

## Test plan
- [ ] `StellarService` — confirm Horizon requests time out at ~30 s under simulated network stall
- [ ] `GET /.well-known/stellar.toml` returns 200 with `Content-Type: text/plain` and correct CORS headers from Next.js frontend
- [ ] `StellarWalletGuard` — valid signature passes, wrong signature / stale timestamp / missing headers each return 401 with the correct `code`
- [ ] `Sep38Service.getQuote` — sell_amount path, buy_amount path, missing-both / both-present errors, fee deduction math