### PR TITLE
feat(stellar): add local transaction signature validation

### DIFF
--- a/backend/src/stellar/stellar.service.spec.ts
+++ b/backend/src/stellar/stellar.service.spec.ts
@@ -4,7 +4,14 @@ import { StellarService, InvestorShare } from './stellar.service';
 import { PinoLogger } from 'nestjs-pino';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { TransactionLog, TxStatus } from './entities/transaction-log.entity';
-import { Keypair, Asset } from '@stellar/stellar-sdk';
+import {
+  Keypair,
+  TransactionBuilder,
+  Operation,
+  Asset,
+  Networks,
+  Account,
+} from '@stellar/stellar-sdk';
 
 /**
  * Unit tests for StellarService — pure logic that doesn't require network calls.
@@ -219,6 +226,101 @@ describe('StellarService', () => {
 
       const status = await service.getTransactionStatus('some-tx-id');
       expect(status).toBe('failed');
+    });
+  });
+
+  describe('validateTransactionSignatures', () => {
+    const TESTNET_PASSPHRASE = Networks.TESTNET;
+
+    /** Builds a minimal signed XDR using a fresh keypair */
+    function buildSignedXdr(signerKeypair: Keypair): string {
+      const account = new Account(signerKeypair.publicKey(), '100');
+      const tx = new TransactionBuilder(account, {
+        fee: '100',
+        networkPassphrase: TESTNET_PASSPHRASE,
+      })
+        .addOperation(
+          Operation.payment({
+            destination: Keypair.random().publicKey(),
+            asset: Asset.native(),
+            amount: '1',
+          }),
+        )
+        .setTimeout(30)
+        .build();
+      tx.sign(signerKeypair);
+      return tx.toXDR();
+    }
+
+    it('returns valid: true when the correct public key signed the transaction', () => {
+      const signer = Keypair.random();
+      const xdr = buildSignedXdr(signer);
+
+      const result = service.validateTransactionSignatures(xdr, signer.publicKey());
+
+      expect(result.valid).toBe(true);
+      expect(result.publicKey).toBe(signer.publicKey());
+      expect(result.signatureCount).toBe(1);
+      expect(result.matchedSignatureIndex).toBe(0);
+      expect(result.error).toBeUndefined();
+    });
+
+    it('returns valid: false when a different public key is checked against a valid signature', () => {
+      const signer = Keypair.random();
+      const unrelated = Keypair.random();
+      const xdr = buildSignedXdr(signer);
+
+      const result = service.validateTransactionSignatures(xdr, unrelated.publicKey());
+
+      expect(result.valid).toBe(false);
+      expect(result.signatureCount).toBe(1);
+      expect(result.matchedSignatureIndex).toBe(-1);
+      expect(result.error).toMatch(/No signature found/i);
+    });
+
+    it('returns valid: false with a parse error when XDR is malformed', () => {
+      const result = service.validateTransactionSignatures(
+        'not-valid-xdr==',
+        Keypair.random().publicKey(),
+      );
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toMatch(/Failed to parse XDR/i);
+    });
+
+    it('returns valid: false when the transaction has no signatures', () => {
+      const signer = Keypair.random();
+      const account = new Account(signer.publicKey(), '100');
+      // Build but do NOT sign
+      const tx = new TransactionBuilder(account, {
+        fee: '100',
+        networkPassphrase: TESTNET_PASSPHRASE,
+      })
+        .addOperation(
+          Operation.payment({
+            destination: Keypair.random().publicKey(),
+            asset: Asset.native(),
+            amount: '1',
+          }),
+        )
+        .setTimeout(30)
+        .build();
+
+      const result = service.validateTransactionSignatures(tx.toXDR(), signer.publicKey());
+
+      expect(result.valid).toBe(false);
+      expect(result.signatureCount).toBe(0);
+      expect(result.error).toMatch(/no signatures/i);
+    });
+
+    it('returns valid: false with an invalid public key error', () => {
+      const signer = Keypair.random();
+      const xdr = buildSignedXdr(signer);
+
+      const result = service.validateTransactionSignatures(xdr, 'not-a-public-key');
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toMatch(/Invalid public key/i);
     });
   });
 

--- a/backend/src/stellar/stellar.service.ts
+++ b/backend/src/stellar/stellar.service.ts
@@ -35,6 +35,17 @@ export interface InvestorShare {
   totalTokens: number;
 }
 
+export interface SignatureValidationResult {
+  valid: boolean;
+  /** Public key that was checked */
+  publicKey: string;
+  /** Number of signatures found on the envelope */
+  signatureCount: number;
+  /** Index of the matching signature, or -1 if none matched */
+  matchedSignatureIndex: number;
+  error?: string;
+}
+
 @Injectable()
 export class StellarService implements OnModuleInit, OnModuleDestroy {
   private readonly server: Horizon.Server;
@@ -875,6 +886,107 @@ export class StellarService implements OnModuleInit, OnModuleDestroy {
     tx.sign(signerKeypair);
     const result = await this.submitWithRetry(tx);
     return (result as any).hash as string;
+  }
+
+  /**
+   * Validates that an XDR transaction envelope carries a valid Ed25519 signature
+   * from the given public key, without submitting to the network.
+   *
+   * Steps:
+   *  1. Decode the XDR envelope and compute the transaction hash (the actual
+   *     payload that signers sign, which includes the network passphrase).
+   *  2. Derive the 4-byte key hint from the supplied public key.
+   *  3. Walk the envelope's decorator signatures; find the one whose hint matches
+   *     and cryptographically verify it with Keypair.verify().
+   *
+   * Returns a SignatureValidationResult so callers can surface precise errors to
+   * the user without an unnecessary round-trip to Horizon.
+   */
+  validateTransactionSignatures(
+    signedXdr: string,
+    expectedPublicKey: string,
+  ): SignatureValidationResult {
+    const base: Omit<SignatureValidationResult, 'valid'> = {
+      publicKey: expectedPublicKey,
+      signatureCount: 0,
+      matchedSignatureIndex: -1,
+    };
+
+    let keypair: Keypair;
+    try {
+      keypair = Keypair.fromPublicKey(expectedPublicKey);
+    } catch {
+      return {
+        ...base,
+        valid: false,
+        error: `Invalid public key: "${expectedPublicKey}" is not a valid Stellar ed25519 public key.`,
+      };
+    }
+
+    let tx: ReturnType<typeof TransactionBuilder.fromXDR>;
+    try {
+      tx = TransactionBuilder.fromXDR(signedXdr, this.networkPassphrase);
+    } catch {
+      return {
+        ...base,
+        valid: false,
+        error: 'Failed to parse XDR envelope. Ensure the transaction was built for the correct network.',
+      };
+    }
+
+    const signatures = tx.signatures;
+    base.signatureCount = signatures.length;
+
+    if (signatures.length === 0) {
+      return {
+        ...base,
+        valid: false,
+        error: 'Transaction envelope contains no signatures.',
+      };
+    }
+
+    // The payload that was signed: SHA-256(network_passphrase_hash || tx_hash_prefix || tx_body)
+    const txHash = tx.hash();
+    const expectedHint = keypair.signatureHint();
+
+    for (let i = 0; i < signatures.length; i++) {
+      const decoratedSig = signatures[i];
+      const hint = decoratedSig.hint();
+
+      // Quick hint check before expensive verify
+      if (!hint.equals(expectedHint)) {
+        continue;
+      }
+
+      const signatureBytes = decoratedSig.signature();
+      const isValid = keypair.verify(txHash, signatureBytes);
+
+      if (isValid) {
+        this.logger.info(
+          { publicKey: expectedPublicKey, signatureIndex: i },
+          'Transaction signature validated successfully',
+        );
+        return {
+          ...base,
+          valid: true,
+          matchedSignatureIndex: i,
+        };
+      }
+
+      // Hint matched but bytes failed — report immediately
+      return {
+        ...base,
+        valid: false,
+        matchedSignatureIndex: i,
+        error: `Signature at index ${i} has a matching hint for key ${expectedPublicKey} but failed cryptographic verification. The transaction may have been tampered with.`,
+      };
+    }
+
+    return {
+      ...base,
+      valid: false,
+      error: `No signature found for public key ${expectedPublicKey}. The transaction has ${signatures.length} signature(s) but none match this key's hint.`,
+    };
   }
 
   /**


### PR DESCRIPTION
Closes #348
Closes #349
Closes #350
Closes #351

## What was done

### `backend/src/stellar/stellar.service.ts`

**New export: `SignatureValidationResult`**

Typed interface returned by the new validation method:
- `valid: boolean` — overall pass/fail
- `publicKey: string` — the key that was checked
- `signatureCount: number` — total signatures found on the envelope
- `matchedSignatureIndex: number` — index of the matching signature, or `-1` if none matched
- `error?: string` — human-readable explanation when `valid` is `false`

**New method: `validateTransactionSignatures(signedXdr, expectedPublicKey)`**

Validates an Ed25519 signature locally without sending the transaction to Horizon. The verification pipeline is:

1. **Parse** — decodes the XDR envelope with `TransactionBuilder.fromXDR()`, using the service's network passphrase so the hash is network-aware. Returns a parse error immediately if the XDR is malformed.
2. **Key check** — constructs a `Keypair` from `expectedPublicKey` to validate the key format before doing any cryptographic work.
3. **Hash** — calls `tx.hash()` to get the exact bytes that were signed (SHA-256 of network passphrase hash + transaction body).
4. **Hint filter** — derives the 4-byte signature hint from the expected key and skips non-matching decorators without running the full verify, keeping the method efficient when envelopes carry multiple signatures.
5. **Verify** — calls `keypair.verify(txHash, signatureBytes)` on the matching-hint decorator. A hint match that fails cryptographic verification reports a tamper-warning error.

Distinct error messages are returned for each failure mode so callers can surface precise feedback to users:
- Invalid key format
- Unparseable XDR
- Envelope has no signatures
- Hint matched but cryptographic check failed (possible tampering)
- No signature found for the given key

Successful validations are logged at `info` level with `publicKey` and `signatureIndex` for auditability.

### `backend/src/stellar/stellar.service.spec.ts`

Five new unit tests added to the existing `StellarService` describe block — all run offline with no mocked Horizon calls:

| Test | Assertion |
|------|-----------|
| correct keypair → passes | `valid: true`, `matchedSignatureIndex: 0` |
| unrelated public key → fails | `valid: false`, `matchedSignatureIndex: -1`, error mentions "No signature found" |
| malformed XDR → fails | `valid: false`, error mentions "Failed to parse XDR" |
| unsigned envelope → fails | `valid: false`, `signatureCount: 0` |
| non-Stellar string as key → fails | `valid: false`, error mentions "Invalid public key" |