### PR TITLE
feat: rate limiting, DB indexes, audit log migration, and custom logger

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -60,12 +60,7 @@ export class AuthController {
   }
 
   @Post('login')
-  @Throttle({
-    default: {
-      limit: parseInt(process.env.RATE_LIMIT_LOGIN || '5'),
-      ttl: parseInt(process.env.RATE_LIMIT_TTL || '60000'),
-    },
-  })
+  @Throttle({ default: { limit: 5, ttl: 60000 } })
   @ApiOperation({ summary: 'Authenticate and receive a JWT' })
   @ApiResponse({ status: 200, description: 'Returns access and refresh JWTs' })
   @ApiResponse({ status: 401, description: 'Invalid credentials' })

--- a/backend/src/common/logger/custom-logger.service.ts
+++ b/backend/src/common/logger/custom-logger.service.ts
@@ -1,0 +1,34 @@
+import { ConsoleLogger, Injectable, LogLevel } from '@nestjs/common';
+
+@Injectable()
+export class CustomLogger extends ConsoleLogger {
+  private readonly isProd = process.env.NODE_ENV === 'production';
+
+  protected formatMessage(
+    logLevel: LogLevel,
+    message: unknown,
+    pidMessage: string,
+    formattedLogLevel: string,
+    contextMessage: string,
+    timestampDiff: string,
+  ): string {
+    if (this.isProd) {
+      return (
+        JSON.stringify({
+          timestamp: new Date().toISOString(),
+          level: logLevel,
+          context: this.context ?? contextMessage.replace(/[[\]]/g, '').trim(),
+          message,
+        }) + '\n'
+      );
+    }
+    return super.formatMessage(
+      logLevel,
+      message,
+      pidMessage,
+      formattedLogLevel,
+      contextMessage,
+      timestampDiff,
+    );
+  }
+}

--- a/backend/src/database/migrations/1716300000006-IndexTxLog.ts
+++ b/backend/src/database/migrations/1716300000006-IndexTxLog.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class IndexTxLog1716300000006 implements MigrationInterface {
+  name = 'IndexTxLog1716300000006';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE INDEX "idx_tx_logs_user_status_created"
+       ON "transaction_logs" ("user_id", "status", "created_at")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "idx_tx_logs_user_status_created"`,
+    );
+  }
+}

--- a/backend/src/database/migrations/1716300000007-CreateTxAuditLogs.ts
+++ b/backend/src/database/migrations/1716300000007-CreateTxAuditLogs.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateTxAuditLogs1716300000007 implements MigrationInterface {
+  name = 'CreateTxAuditLogs1716300000007';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "transaction_audit_log" (
+        "id"         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        "user_id"    UUID REFERENCES users(id) ON DELETE SET NULL,
+        "tx_hash"    TEXT,
+        "status"     TEXT NOT NULL DEFAULT 'pending'
+                       CHECK (status IN ('pending', 'success', 'failed')),
+        "error_code" TEXT,
+        "amount"     NUMERIC(20, 7),
+        "created_at" TIMESTAMPTZ DEFAULT now()
+      )
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "transaction_audit_log"`);
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -9,11 +9,15 @@ import {
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 import { applySecurityHeaders } from './common/middleware/security-headers.middleware';
+import { CustomLogger } from './common/logger/custom-logger.service';
 
 async function bootstrap() {
   // rawBody: true preserves the unparsed request buffer on req.rawBody,
   // which is required by WebhookSignatureGuard for HMAC verification.
-  const app = await NestFactory.create(AppModule, { rawBody: true });
+  const app = await NestFactory.create(AppModule, {
+    rawBody: true,
+    logger: new CustomLogger(),
+  });
 
   app.getHttpAdapter().getInstance().disable('x-powered-by');
 app.use(helmet({


### PR DESCRIPTION
## Summary

- **#331** — Hardened login route with fixed `@Throttle({ default: { limit: 5, ttl: 60000 } })` replacing env-var-driven values; HTTP 429 already documented via `@ApiResponse`.
- **#332** — Added migration `1716300000006-IndexTxLog.ts` creating a composite index on `transaction_logs(user_id, status, created_at)` to speed up audit log queries.
- **#333** — Added `CustomLogger` extending NestJS `ConsoleLogger`; emits structured JSON logs (timestamp, level, context, message) in production and retains default colorized output in development. Wired into `NestFactory.create` in `main.ts`.
- **#334** — Added migration `1716300000007-CreateTxAuditLogs.ts` building the `transaction_audit_log` table with fields: `id`, `user_id`, `tx_hash`, `status`, `error_code`, `amount`, `created_at`.

Closes #331
Closes #332
Closes #333
Closes #334

## Test plan
- [ ] Login endpoint returns 429 after 5 requests within 60 s
- [ ] Run migration and verify `idx_tx_logs_user_status_created` index exists via `\d transaction_logs`
- [ ] Set `NODE_ENV=production` and confirm logs are JSON; unset and confirm colorized output
- [ ] Run migration and verify `transaction_audit_log` table schema