### PR TITLE
feat(auth): add unique constraint on user.email (#325)

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -136,7 +136,19 @@ export class AuthService {
       emailVerificationToken,
     });
 
-    const saved = await this.userRepo.save(user);
+    let saved: User;
+    try {
+      saved = await this.userRepo.save(user);
+    } catch (err: any) {
+      // PostgreSQL unique_violation code
+      if (err?.code === '23505') {
+        throw new ConflictException({
+          code: 'EMAIL_EXISTS',
+          message: 'Email is already registered.',
+        });
+      }
+      throw err;
+    }
 
     await this.sendVerificationEmail(saved.email, emailVerificationToken);
 

--- a/backend/src/database/migrations/1716300000005-UniqueUserEmail.ts
+++ b/backend/src/database/migrations/1716300000005-UniqueUserEmail.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UniqueUserEmail1716300000005 implements MigrationInterface {
+  name = 'UniqueUserEmail1716300000005';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user" ADD CONSTRAINT "uq_user_email" UNIQUE ("email")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user" DROP CONSTRAINT "uq_user_email"`,
+    );
+  }
+}


### PR DESCRIPTION
- Add migration 1716300000005-UniqueUserEmail to enforce UNIQUE constraint on user.email at the database level
- Catch PostgreSQL unique_violation (23505) in AuthService.register to handle race conditions between the pre-check and save

closes #325 