### PR TITLE
feat: expose public GET /config endpoint

### DIFF
--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -1,0 +1,35 @@
+import { Controller, Get } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+@ApiTags('config')
+@Controller('config')
+export class AppController {
+  private cachedConfig: Record<string, unknown> | null = null;
+
+  constructor(private readonly config: ConfigService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Return public platform configuration' })
+  @ApiResponse({ status: 200, description: 'Public configuration values' })
+  getConfig(): Record<string, unknown> {
+    if (!this.cachedConfig) {
+      this.cachedConfig = {
+        stellarNetwork: this.config.get<string>('STELLAR_NETWORK', 'testnet'),
+        platformFeePercent: parseFloat(
+          this.config.get<string>('PLATFORM_FEE_PERCENT', '2'),
+        ),
+        tokenPriceUsd: parseFloat(
+          this.config.get<string>('TOKEN_PRICE_USD', '100'),
+        ),
+        allowedCountries: (
+          this.config.get<string>('ALLOWED_COUNTRIES', '') || ''
+        )
+          .split(',')
+          .map((c) => c.trim())
+          .filter(Boolean),
+      };
+    }
+    return this.cachedConfig;
+  }
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,4 +1,5 @@
 import { Module, MiddlewareConsumer, NestModule } from '@nestjs/common';
+import { AppController } from './app.controller';
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { LoggerModule } from 'nestjs-pino';
@@ -26,6 +27,7 @@ import { validateEnvironment } from './config/env.validation';
 import { ScheduleModule } from '@nestjs/schedule';
 
 @Module({
+  controllers: [AppController],
   imports: [
     // Register ClsModule globally — no auto-mount; we mount manually below
     // to guarantee ordering: ClsMiddleware runs before CorrelationIdMiddleware


### PR DESCRIPTION
**Description**
Implement a public configuration endpoint that exposes non-sensitive system settings required by the frontend, such as the active Stellar network, platform fee percentages, and supported countries. The endpoint should exclude all sensitive information and leverage in-memory caching to provide efficient, low-latency access to configuration data.
closes #327 