### PR TITLE
feat(auth): implement admin audit logging for status changes (#326)

### DIFF
--- a/backend/src/auth/admin.controller.ts
+++ b/backend/src/auth/admin.controller.ts
@@ -20,7 +20,7 @@ import { AuthGuard } from '@nestjs/passport';
 import { AuthService } from './auth.service';
 import { User } from './entities/user.entity';
 import { ApiBody } from '@nestjs/swagger';
-import { IsIn, IsString, IsBoolean, IsUUID } from 'class-validator';
+import { IsIn, IsString, IsBoolean, IsUUID, IsOptional } from 'class-validator';
 import { Roles } from './decorators/roles.decorator';
 import { RolesGuard } from './roles.guard';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -31,6 +31,9 @@ import { StellarService } from '../stellar/stellar.service';
 class UpdateUserRoleDto {
   @IsIn(['farmer', 'trader', 'investor', 'company_admin', 'admin'])
   role: 'farmer' | 'trader' | 'investor' | 'company_admin' | 'admin';
+
+  @IsString()
+  reason: string;
 }
 
 class FreezeAssetDto {
@@ -76,8 +79,9 @@ export class AdminController {
   async approveKyc(
     @Request() req: AuthRequest,
     @Param('userId') userId: string,
+    @Query('reason') reason?: string,
   ) {
-    return this.authService.approveKyc(userId);
+    return this.authService.approveKyc(userId, req.user.id, reason);
   }
 
   @Post('kyc/:id/approve-corporate')
@@ -88,8 +92,9 @@ export class AdminController {
   async approveCorporateKyc(
     @Request() req: AuthRequest,
     @Param('id') id: string,
+    @Query('reason') reason?: string,
   ) {
-    return this.authService.approveCorporateKycSubmission(id);
+    return this.authService.approveCorporateKycSubmission(id, req.user.id, reason);
   }
 
   @Post('users/:userId/role')
@@ -100,7 +105,7 @@ export class AdminController {
     @Param('userId') userId: string,
     @Body() dto: UpdateUserRoleDto,
   ) {
-    return this.authService.updateUserRole(userId, dto.role);
+    return this.authService.updateUserRole(userId, dto.role, req.user.id, dto.reason);
   }
 
   @Post('freeze-asset')

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -15,10 +15,12 @@ import { QueueModule } from '../queue/queue.module';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { TradeDeal } from '../trade-deals/entities/trade-deal.entity';
 import { OfacSanctionsCheckService } from './utils/ofac-sanctions-check';
+import { LoginLog } from '../database/entities/login-log.entity';
+import { AdminAction } from '../database/entities/admin-action.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([User, KycSubmission, TradeDeal, LoginLog]),
+    TypeOrmModule.forFeature([User, KycSubmission, TradeDeal, LoginLog, AdminAction]),
     QueueModule,
     NotificationsModule,
     PassportModule,

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -33,6 +33,8 @@ import { NotificationsService } from '../notifications/notifications.service';
 import { JwtPayload } from './jwt.strategy';
 import { sanitizeRedirectUrl } from './utils/redirect-sanitizer';
 import { OfacSanctionsCheckService } from './utils/ofac-sanctions-check';
+import { LoginLog } from '../database/entities/login-log.entity';
+import { AdminAction } from '../database/entities/admin-action.entity';
 
 const LOCKOUT_MAX_ATTEMPTS = 5;
 const LOCKOUT_DURATION_MS = 15 * 60 * 1000; // 15 minutes
@@ -50,6 +52,8 @@ export class AuthService {
     private readonly kycRepo: Repository<KycSubmission>,
     @InjectRepository(LoginLog)
     private readonly loginLogRepo: Repository<LoginLog>,
+    @InjectRepository(AdminAction)
+    private readonly adminActionRepo: Repository<AdminAction>,
     private readonly jwtService: JwtService,
     private readonly configService: ConfigService,
     private readonly queueService: QueueService,
@@ -402,6 +406,8 @@ export class AuthService {
 
   async approveCorporateKycSubmission(
     submissionId: string,
+    adminId: string,
+    reason?: string,
   ): Promise<{ kycStatus: string }> {
     const submission = await this.kycRepo.findOne({
       where: { id: submissionId },
@@ -435,10 +441,20 @@ export class AuthService {
     user.kycStatus = 'verified';
     await this.userRepo.save(user);
 
+    await this.adminActionRepo.save(
+      this.adminActionRepo.create({
+        adminId,
+        targetUserId: user.id,
+        action: 'approve_corporate_kyc',
+        payload: { submissionId },
+        reason: reason ?? null,
+      }),
+    );
+
     return { kycStatus: user.kycStatus };
   }
 
-  async approveKyc(userId: string): Promise<{ kycStatus: string }> {
+  async approveKyc(userId: string, adminId: string, reason?: string): Promise<{ kycStatus: string }> {
     const user = await this.userRepo.findOne({ where: { id: userId } });
     if (!user) throw new NotFoundException('User not found.');
 
@@ -469,6 +485,16 @@ export class AuthService {
     user.kycStatus = 'verified';
     await this.userRepo.save(user);
 
+    await this.adminActionRepo.save(
+      this.adminActionRepo.create({
+        adminId,
+        targetUserId: user.id,
+        action: 'approve_kyc',
+        payload: { submissionId: submission.id },
+        reason: reason ?? null,
+      }),
+    );
+
     console.log(
       `KYC manually verified for user ${user.email} — notification queued.`,
     );
@@ -486,13 +512,29 @@ export class AuthService {
   async updateUserRole(
     userId: string,
     role: User['role'],
+    adminId?: string,
+    reason?: string,
   ): Promise<{ id: string; role: string }> {
     const user = await this.userRepo.findOne({ where: { id: userId } });
     if (!user) throw new NotFoundException('User not found.');
 
+    const previousRole = user.role;
     user.role = role;
     user.tokenVersion = (user.tokenVersion ?? 0) + 1;
     const saved = await this.userRepo.save(user);
+
+    if (adminId) {
+      await this.adminActionRepo.save(
+        this.adminActionRepo.create({
+          adminId,
+          targetUserId: userId,
+          action: 'update_user_role',
+          payload: { previousRole, newRole: role },
+          reason: reason ?? null,
+        }),
+      );
+    }
+
     return { id: saved.id, role: saved.role };
   }
 

--- a/backend/src/database/entities/admin-action.entity.ts
+++ b/backend/src/database/entities/admin-action.entity.ts
@@ -1,0 +1,27 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from 'typeorm';
+
+export type AdminActionType = 'approve_kyc' | 'approve_corporate_kyc' | 'update_user_role' | 'freeze_asset';
+
+@Entity('admin_actions')
+export class AdminAction {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'admin_id' })
+  adminId: string;
+
+  @Column({ name: 'target_user_id', nullable: true })
+  targetUserId: string | null;
+
+  @Column({ length: 50 })
+  action: AdminActionType;
+
+  @Column({ type: 'jsonb', nullable: true })
+  payload: Record<string, unknown> | null;
+
+  @Column({ nullable: true })
+  reason: string | null;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+}

--- a/backend/src/database/migrations/1790000000000-CreateAdminActions.ts
+++ b/backend/src/database/migrations/1790000000000-CreateAdminActions.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateAdminActions1790000000000 implements MigrationInterface {
+  name = 'CreateAdminActions1790000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "admin_actions" (
+        "id"             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        "admin_id"       UUID NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+        "target_user_id" UUID REFERENCES users(id) ON DELETE SET NULL,
+        "action"         VARCHAR(50) NOT NULL,
+        "payload"        JSONB,
+        "reason"         TEXT,
+        "created_at"     TIMESTAMPTZ NOT NULL DEFAULT now()
+      )
+    `);
+    await queryRunner.query(`CREATE INDEX "idx_admin_actions_admin_id" ON "admin_actions" ("admin_id")`);
+    await queryRunner.query(`CREATE INDEX "idx_admin_actions_target_user_id" ON "admin_actions" ("target_user_id")`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "admin_actions"`);
+  }
+}

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
-import { User } from '../auth/entities/user.entity'; // Corrected Path
+import { User } from '../auth/entities/user.entity';
 import { TradeDeal } from '../trade-deals/entities/trade-deal.entity';
 import { Investment } from '../investments/entities/investment.entity';
 import { ShipmentMilestone } from '../shipments/entities/shipment-milestone.entity';
 import { PaymentDistribution } from '../escrow/entities/payment-distribution.entity';
+import { KycSubmission } from '../auth/entities/kyc-submission.entity';
 import { TradeDealsModule } from '../trade-deals/trade-deals.module';
 
 @Module({
@@ -17,6 +18,7 @@ import { TradeDealsModule } from '../trade-deals/trade-deals.module';
       Investment,
       ShipmentMilestone,
       PaymentDistribution,
+      KycSubmission,
     ]),
     TradeDealsModule,
   ],


### PR DESCRIPTION
- Add AdminAction entity with adminId, targetUserId, action, payload, reason
- Add migration 1790000000000-CreateAdminActions for admin_actions table
- Inject AdminAction repo into AuthService; log on approveKyc, approveCorporateKycSubmission, and updateUserRole
- Register AdminAction and LoginLog in AuthModule
- Admin endpoints now accept optional ?reason query param (KYC approvals) and required reason body field (role update); adminId sourced from JWT
closes #326