### PR TITLE
feat: Add metadata JSONB column to documents table

### DIFF
--- a/backend/src/database/migrations/1716300000004-AddMetadataToDocument.ts
+++ b/backend/src/database/migrations/1716300000004-AddMetadataToDocument.ts
@@ -1,0 +1,33 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddMetadataToDocument1716300000004 implements MigrationInterface {
+  name = 'AddMetadataToDocument1716300000004';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "documents"
+        ADD COLUMN IF NOT EXISTS "metadata" JSONB DEFAULT '{}'::jsonb
+    `);
+
+    // Add a comment to document the metadata structure
+    await queryRunner.query(`
+      COMMENT ON COLUMN "documents"."metadata" IS 'Document metadata including dimensions, page count, and detected OCR languages'
+    `);
+
+    // Optionally create a GIN index for JSONB queries if needed for performance
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "idx_documents_metadata" 
+      ON "documents" USING GIN ("metadata")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DROP INDEX IF EXISTS "idx_documents_metadata"
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "documents" DROP COLUMN IF EXISTS "metadata"
+    `);
+  }
+}

--- a/backend/src/trade-deals/entities/document.entity.ts
+++ b/backend/src/trade-deals/entities/document.entity.ts
@@ -15,6 +15,17 @@ export type DocumentType =
   | 'export_certificate'
   | 'warehouse_receipt';
 
+export interface DocumentMetadata {
+  dimensions?: {
+    width: number;
+    height: number;
+    unit?: string;
+  };
+  pageCount?: number;
+  detectedLanguages?: string[];
+  [key: string]: any; // Allow additional metadata fields
+}
+
 @Entity('documents')
 export class Document {
   @PrimaryGeneratedColumn('uuid')
@@ -43,6 +54,9 @@ export class Document {
 
   @Column({ name: 'signature_verified', default: false })
   signatureVerified: boolean;
+
+  @Column({ name: 'metadata', type: 'jsonb', default: {} })
+  metadata: DocumentMetadata;
 
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;


### PR DESCRIPTION
- Created migration 1716300000004-AddMetadataToDocument.ts
- Added metadata column of type JSONB with default {}
- Updated Document entity with DocumentMetadata interface
- Added GIN index for efficient JSONB queries
- Metadata captures document dimensions, page counts, and detected OCR languages

Resolves #324 