### PR TITLE
#316 [Backend] Optimize JSON Serialization for BigInt numbers FIXED

### DIFF
--- a/backend/src/common/interceptors/json-bigint.interceptor.ts
+++ b/backend/src/common/interceptors/json-bigint.interceptor.ts
@@ -17,21 +17,52 @@ export class JsonBigIntInterceptor implements NestInterceptor {
     return next.handle().pipe(map((data) => this.serializeBigInts(data)));
   }
 
-  private serializeBigInts(value: unknown): unknown {
+  private serializeBigInts(value: unknown, seen = new WeakSet<object>()): unknown {
     if (typeof value === 'bigint') {
       return value.toString();
     }
+
+    if (value === null || typeof value !== 'object') {
+      return value;
+    }
+
+    // Prevent circular reference infinite recursion
+    if (seen.has(value as object)) {
+      return '[Circular]';
+    }
+    seen.add(value as object);
+
     if (Array.isArray(value)) {
-      return value.map((item) => this.serializeBigInts(item));
+      return value.map((item) => this.serializeBigInts(item, seen));
     }
-    if (value !== null && typeof value === 'object') {
-      return Object.fromEntries(
-        Object.entries(value as Record<string, unknown>).map(([key, val]) => [
-          key,
-          this.serializeBigInts(val),
-        ]),
-      );
+
+    // Preserve special built-in objects that JSON.stringify handles natively.
+    // Converting them via Object.entries would corrupt them (e.g., Date -> {}).
+    if (value instanceof Date) {
+      return value;
     }
-    return value;
+    if (value instanceof RegExp) {
+      return value;
+    }
+    // Buffer check (Node.js)
+    if (typeof Buffer !== 'undefined' && Buffer.isBuffer(value)) {
+      return value;
+    }
+
+    const objectTag = Object.prototype.toString.call(value);
+
+    // Only recursively process plain objects.
+    // For other objects (Map, Set, class instances, etc.), return as-is
+    // and rely on their toJSON implementation or the global BigInt.toJSON shim.
+    if (objectTag !== '[object Object]') {
+      return value;
+    }
+
+    const obj = value as Record<string, unknown>;
+    const result: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(obj)) {
+      result[key] = this.serializeBigInts(val, seen);
+    }
+    return result;
   }
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,4 +1,15 @@
 import 'dotenv-vault/config';
+
+// Shim BigInt JSON serialization globally.
+// Stellar ledger amounts (stroops, sequence numbers) can exceed Number.MAX_SAFE_INTEGER.
+// Without this, JSON.stringify throws: "TypeError: Do not know how to serialize a BigInt".
+// This ensures any BigInt that slips through the interceptor is still safely serialized as a string.
+if (!(BigInt.prototype as any).toJSON) {
+  (BigInt.prototype as any).toJSON = function () {
+    return this.toString();
+  };
+}
+
 import { NestFactory } from '@nestjs/core';
 import helmet from 'helmet';
 import {
@@ -11,6 +22,7 @@ import { Transport, MicroserviceOptions } from '@nestjs/microservices';
 import { AppModule } from './app.module';
 import { applySecurityHeaders } from './common/middleware/security-headers.middleware';
 import { CustomLogger } from './common/logger/custom-logger.service';
+import { JsonBigIntInterceptor } from './common/interceptors/json-bigint.interceptor';
 import * as cookieParser from 'cookie-parser';
 import * as csrf from 'csurf';
 
@@ -71,6 +83,10 @@ app.use(helmet({
   app.use('/csrf-token', (req: any, res: any) => {
     res.json({ csrfToken: req.csrfToken() });
   });
+
+  // Global interceptor to convert BigInt values (Stellar ledger amounts, sequence numbers)
+  // to strings in JSON responses, preventing precision loss and serialization errors.
+  app.useGlobalInterceptors(new JsonBigIntInterceptor());
 
   app.useGlobalPipes(
     new ValidationPipe({


### PR DESCRIPTION
### Findings and Fix Features – Stellar BigInt Serialization (Agri-fi Backend)

**Findings in the codebase (backend/src/):**

1. **Interceptor existed but was dead code**
   - File `backend/src/common/interceptors/json-bigint.interceptor.ts` was created in commit `1852d03` (PR #571 – "Verify JSON-BigInt serialization interceptors", May 2026)
   - It was **never registered** in `main.ts`, `AppModule`, or any controller – so 0% of REST traffic was protected
   - Result: Any Stellar ledger amount returned as `bigint` (sequence numbers, stroops, Soroban i128 values) would cause Express `JSON.stringify` to throw: `TypeError: Do not know how to serialize a BigInt` → 500 error, plus precision loss if coerced to Number

2. **Original interceptor was corrupting responses**
   - `serializeBigInts()` used:
     ```ts
     Object.fromEntries(Object.entries(value as Record<string, unknown>)...)
     ```
   - This destroys special objects:
     - `Date` → `{}`  (loses timestamp)
     - `Buffer` → `{0:72,1:105,...}` (loses Buffer type)
     - `RegExp`, `Map`, `Set`, class instances → plain `{}` / mangled
   - No circular-reference guard → `RangeError: Maximum call stack size exceeded` on cyclic objects
   - No plain-object check → walks into every object, breaking Nest's built-in serializers

3. **No global JSON fallback**
   - `main.ts` had no `BigInt.prototype.toJSON` shim
   - Express `res.json()` uses native `JSON.stringify` which throws on BigInt
   - Even with the interceptor, a missed BigInt in an error response, logger, or 3rd-party middleware would crash the process

4. **Stellar usage in the repo**
   - `src/soroban/soroban.service.ts`: `fundingTarget: bigint`, `revenueAmount: bigint`
   - `src/stellar/stellar-monitor.service.ts`: `sequenceNumber = BigInt(account.sequenceNumber())`
   - `src/stellar/stellar.service.ts`: `nextSeq = (BigInt(current.seq) + 1n).toString()`
   - `src/queue/queue.processor.ts`: `fundingTargetStroops = BigInt(...)`
   - None of these are currently returned directly in REST responses, but the platform is designed to expose ledger values – the bug was preventive / production-readiness, exactly as the Issue states: "Stellar ledger amounts can exceed standard 32-bit integer limits, causing serialization precision issues"

---

CLOSE #316 

**Fix Features Implemented:**

**A. `backend/src/common/interceptors/json-bigint.interceptor.ts` – Robust recursive serializer**

1. **BigInt → string conversion (core)**
   ```ts
   if (typeof value === 'bigint') return value.toString();
   ```
   Preserves full 64-bit / i128 Stellar precision. Example: `9007199254740999999n` → `"9007199254740999999"`

2. **Circular-reference safe**
   ```ts
   private serializeBigInts(value: unknown, seen = new WeakSet<object>())
   if (seen.has(value as object)) return '[Circular]';
   ```
   Prevents stack overflow on cyclic graphs

3. **Special built-ins preserved**
   ```ts
   if (value instanceof Date) return value;
   if (value instanceof RegExp) return value;
   if (typeof Buffer !== 'undefined' && Buffer.isBuffer(value)) return value;
   ```
   Dates stay Dates (JSON → ISO string), Buffers stay Buffers – no `{}` corruption

4. **Plain-object only walk**
   ```ts
   const objectTag = Object.prototype.toString.call(value);
   if (objectTag !== '[object Object]') return value;
   ```
   Map, Set, class instances, etc. are returned untouched – they rely on their own `toJSON` or the global BigInt shim. Prevents data loss.

5. **Full nesting support**
   - Arrays: `value.map(item => this.serializeBigInts(item, seen))`
   - Plain objects: `for (const [key, val] of Object.entries(obj)) result[key] = serializeBigInts(val, seen)`
   - Null / primitives pass through unchanged
   - Standard numbers (`count: 42`, `price: 19.99`, `Number.MAX_SAFE_INTEGER`) are left as numbers

**B. `backend/src/main.ts` – Global wiring + defense-in-depth**

1. **Global BigInt JSON shim – executed before Nest boots**
   ```ts
   // Shim BigInt JSON serialization globally.
   // Stellar ledger amounts (stroops, sequence numbers) can exceed Number.MAX_SAFE_INTEGER.
   if (!(BigInt.prototype as any).toJSON) {
     (BigInt.prototype as any).toJSON = function () { return this.toString(); };
   }
   ```
   - Guarantees `JSON.stringify({a: 1n})` → `{"a":"1"}` instead of TypeError
   - Catches any BigInt that slips past the interceptor (error handlers, 3rd-party middleware, etc.)
   - Placed at the very top of `main.ts`, before any imports that might serialize

2. **Global interceptor registration**
   ```ts
   import { JsonBigIntInterceptor } from './common/interceptors/json-bigint.interceptor';
   ...
   // Global interceptor to convert BigInt values (Stellar ledger amounts, sequence numbers)
   // to strings in JSON responses, preventing precision loss and serialization errors.
   app.useGlobalInterceptors(new JsonBigIntInterceptor());
   ```
   - Registered after CSRF middleware, before global ValidationPipe
   - Applies to **all** REST controllers (auth, trade-deals, investments, stellar, soroban, shipments, documents, users, sep24)
   - No DI dependencies, stateless – safe for global use

**Result:** Stellar ledger BigInts are now safely serialized as strings at two layers: explicit interceptor conversion in Nest, plus global JSON.toJSON fallback in Express. No precision loss, no 500 crashes, no Date/Buffer corruption, circular-safe.