### PR TITLE
feat: implement cron job to expire trade deals

### DIFF
--- a/backend/src/trade-deals/entities/trade-deal.entity.ts
+++ b/backend/src/trade-deals/entities/trade-deal.entity.ts
@@ -20,7 +20,8 @@ export type TradeDealStatus =
   | 'delivered'
   | 'completed'
   | 'failed'
-  | 'canceled';
+  | 'canceled'
+  | 'expired';
 
 @Entity('trade_deals')
 export class TradeDeal {
@@ -88,6 +89,7 @@ export class TradeDeal {
       'completed',
       'failed',
       'canceled',
+      'expired',
     ],
     example: 'open',
   })

--- a/backend/src/trade-deals/trade-deals-cron.service.ts
+++ b/backend/src/trade-deals/trade-deals-cron.service.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { PinoLogger } from 'nestjs-pino';
+import { TradeDeal } from './entities/trade-deal.entity';
+import { TradeDealsService } from './trade-deals.service';
+
+@Injectable()
+export class TradeDealsCronService {
+  constructor(
+    @InjectRepository(TradeDeal)
+    private readonly tradeDealRepo: Repository<TradeDeal>,
+    private readonly tradeDealsService: TradeDealsService,
+    private readonly logger: PinoLogger,
+  ) {
+    this.logger.setContext(TradeDealsCronService.name);
+  }
+
+  @Cron(CronExpression.EVERY_HOUR)
+  async expireOverdueDeals(): Promise<void> {
+    this.logger.info('Running cron job: expire overdue trade deals');
+
+    const now = new Date();
+
+    const overdueDeals = await this.tradeDealRepo
+      .createQueryBuilder('deal')
+      .where('deal.status = :status', { status: 'open' })
+      .andWhere('deal.delivery_date < :now', { now })
+      .getMany();
+
+    if (overdueDeals.length === 0) {
+      this.logger.info('No overdue deals found');
+      return;
+    }
+
+    this.logger.info(
+      { count: overdueDeals.length },
+      `Found ${overdueDeals.length} overdue deal(s) to expire`,
+    );
+
+    for (const deal of overdueDeals) {
+      try {
+        await this.tradeDealsService.expireDeal(deal.id);
+        this.logger.info({ dealId: deal.id }, 'Successfully expired deal');
+      } catch (error) {
+        this.logger.error(
+          { dealId: deal.id, error: error.message },
+          'Failed to expire deal',
+        );
+      }
+    }
+  }
+}

--- a/backend/src/trade-deals/trade-deals.module.ts
+++ b/backend/src/trade-deals/trade-deals.module.ts
@@ -10,6 +10,7 @@ import { User } from '../auth/entities/user.entity';
 import { StellarModule } from '../stellar/stellar.module';
 import { QueueModule } from '../queue/queue.module';
 import { TradeDealsGuard } from './trade-deals.guard';
+import { TradeDealsCronService } from './trade-deals-cron.service';
 
 @Module({
   imports: [
@@ -24,7 +25,7 @@ import { TradeDealsGuard } from './trade-deals.guard';
     QueueModule,
   ],
   controllers: [TradeDealsController],
-  providers: [TradeDealsService, TradeDealsGuard],
+  providers: [TradeDealsService, TradeDealsGuard, TradeDealsCronService],
   exports: [TradeDealsService],
 })
 export class TradeDealsModule {}

--- a/backend/src/trade-deals/trade-deals.service.ts
+++ b/backend/src/trade-deals/trade-deals.service.ts
@@ -479,7 +479,112 @@ export class TradeDealsService {
     return this.tradeDealRepo.save(deal);
   }
 
-  async findByUser(userId: string, role: string): Promise<any[]> {
+  async expireDeal(dealId: string): Promise<TradeDeal> {
+    const deal = await this.tradeDealRepo.findOne({
+      where: { id: dealId },
+      relations: ['investments', 'investments.investor'],
+    });
+
+    if (!deal) {
+      throw new NotFoundException('Trade deal not found.');
+    }
+
+    if (deal.status !== 'open') {
+      throw new UnprocessableEntityException({
+        code: 'DEAL_NOT_OPEN',
+        message: `Cannot expire a deal in "${deal.status}" status. Only open deals can be expired.`,
+      });
+    }
+
+    const confirmedInvestments =
+      deal.investments?.filter(
+        (inv) => inv.status === InvestmentStatus.CONFIRMED,
+      ) || [];
+
+    if (
+      deal.issuerPublicKey &&
+      deal.issuerSecretKey &&
+      deal.stellarAssetTxId
+    ) {
+      const investorShares: { walletAddress: string; tokenAmount: number }[] =
+        confirmedInvestments
+          .filter((inv) => inv.investor?.walletAddress)
+          .map((inv) => ({
+            walletAddress: inv.investor.walletAddress as string,
+            tokenAmount: Number(inv.tokenAmount),
+          }));
+
+      const tokensSold = investorShares.reduce(
+        (acc, curr) => acc + curr.tokenAmount,
+        0,
+      );
+      const unsoldTokens = Number(deal.tokenCount) - tokensSold;
+
+      if (unsoldTokens > 0 && deal.escrowPublicKey) {
+        investorShares.push({
+          walletAddress: deal.escrowPublicKey,
+          tokenAmount: unsoldTokens,
+        });
+      }
+
+      if (investorShares.length > 0) {
+        const issuerSecret = await this.stellarService.decryptSecret(
+          deal.issuerSecretKey,
+        );
+
+        this.logger.info(
+          {
+            dealId,
+            tokenCount: deal.tokenCount,
+            holders: investorShares.length,
+          },
+          'Initiating clawback for expired deal',
+        );
+
+        await this.stellarService.clawbackTokens(
+          deal.tokenSymbol,
+          deal.issuerPublicKey,
+          issuerSecret,
+          investorShares,
+        );
+      }
+    }
+
+    if (confirmedInvestments.length > 0) {
+      await this.investmentRepo.update(
+        confirmedInvestments.map((inv) => inv.id),
+        { status: InvestmentStatus.REFUNDED },
+      );
+      this.logger.info(
+        { dealId, refundedCount: confirmedInvestments.length },
+        'Refunded confirmed investments for expired deal',
+      );
+    }
+
+    deal.status = 'expired';
+    deal.appTraceId = `app-${Date.now().toString(36)}-${Math.random().toString(36).substring(2, 10)}`;
+
+    const saved = await this.tradeDealRepo.save(deal);
+
+    this.queueService.emit('email.notification', {
+      type: 'deal_expired',
+      dealId,
+      commodity: deal.commodity,
+      traderId: deal.traderId,
+      farmerId: deal.farmerId,
+    });
+
+    this.queueService.emit('admin.alert', {
+      type: 'deal_expired',
+      dealId,
+      commodity: deal.commodity,
+      timestamp: new Date().toISOString(),
+    });
+
+    return saved;
+  }
+
+  async findByUser(userId: string, role: string): Promise<any[]>{
     if (role !== 'farmer' && role !== 'trader') {
       return [];
     }


### PR DESCRIPTION
## Summary

Closes #323 

Implements a cron job that automatically marks trade deals as expired when they fail to reach their funding target before the delivery deadline passes.

## Changes

### `backend/src/trade-deals/entities/trade-deal.entity.ts`
- Added `'expired'` to the `TradeDealStatus` union type and Swagger `@ApiProperty` enum list.

### `backend/src/trade-deals/trade-deals.service.ts`
- Added `expireDeal(dealId)` method that:
  - Validates the deal is in `'open'` status
  - Claws back all issued tokens from investors and the escrow account via Stellar `clawbackTokens`
  - Refunds confirmed investments by setting their status to `REFUNDED`
  - Sets deal status to `'expired'`
  - Emits `email.notification` and `admin.alert` events via the queue service

### `backend/src/trade-deals/trade-deals-cron.service.ts` (new)
- Scheduled task using `@Cron(CronExpression.EVERY_HOUR)` from `@nestjs/schedule`
- Queries for deals where `status = 'open'` AND `delivery_date < NOW()`
- Processes each overdue deal through `TradeDealsService.expireDeal()` with per-deal error isolation

### `backend/src/trade-deals/trade-deals.module.ts`
- Registered `TradeDealsCronService` in the module providers

## Notes
- `ScheduleModule.forRoot()` and `@nestjs/schedule` were already configured globally — no changes needed outside the trade-deals module
- The cron follows the existing pattern used by `StellarArchiverService`, `StellarMonitorService`, `SorobanListenerService`, and `QueueAlertService`
- Escrow refund logic mirrors the existing `cancelDeal()` method but skips the trader authorization check since this is a system-triggered operation
- Uses `await` on `decryptSecret` (unlike the pre-existing `cancelDeal` call site) for correctness
