### PR TITLE
Draft persistence, Help Center, portfolio chart, and document verification

### DIFF
--- a/backend/src/auth/admin.controller.ts
+++ b/backend/src/auth/admin.controller.ts
@@ -20,13 +20,22 @@ import { AuthGuard } from '@nestjs/passport';
 import { AuthService } from './auth.service';
 import { User } from './entities/user.entity';
 import { ApiBody } from '@nestjs/swagger';
-import { IsIn, IsString, IsBoolean, IsUUID, IsOptional } from 'class-validator';
+import {
+  IsIn,
+  IsString,
+  IsBoolean,
+  IsUUID,
+  IsOptional,
+  MinLength,
+} from 'class-validator';
 import { Roles } from './decorators/roles.decorator';
 import { RolesGuard } from './roles.guard';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { TradeDeal } from '../trade-deals/entities/trade-deal.entity';
+import { Document } from '../trade-deals/entities/document.entity';
 import { StellarService } from '../stellar/stellar.service';
+import { AdminAction } from '../database/entities/admin-action.entity';
 
 class UpdateUserRoleDto {
   @IsIn(['farmer', 'trader', 'investor', 'company_admin', 'admin'])
@@ -47,6 +56,12 @@ class FreezeAssetDto {
   freeze: boolean;
 }
 
+class RejectDocumentDto {
+  @IsString()
+  @MinLength(3)
+  reason: string;
+}
+
 interface AuthRequest extends Request {
   user: User;
 }
@@ -62,7 +77,102 @@ export class AdminController {
     private readonly stellarService: StellarService,
     @InjectRepository(TradeDeal)
     private readonly tradeDealRepo: Repository<TradeDeal>,
+    @InjectRepository(Document)
+    private readonly documentRepo: Repository<Document>,
+    @InjectRepository(AdminAction)
+    private readonly adminActionRepo: Repository<AdminAction>,
   ) {}
+
+  @Get('documents')
+  @ApiOperation({ summary: 'List uploaded documents for admin verification' })
+  @ApiResponse({ status: 200, description: 'List of documents' })
+  async listDocuments(
+    @Query('status') status?: 'pending' | 'approved' | 'rejected',
+  ) {
+    return this.documentRepo.find({
+      where: status ? { verificationStatus: status } : {},
+      relations: ['tradeDeal', 'uploader'],
+      // Explicitly whitelist relation columns — `uploader` is a full User
+      // entity and must never expose passwordHash or other PII by default.
+      select: {
+        id: true,
+        tradeDealId: true,
+        uploaderId: true,
+        docType: true,
+        ipfsHash: true,
+        storageUrl: true,
+        stellarTxId: true,
+        signatureVerified: true,
+        verificationStatus: true,
+        rejectionReason: true,
+        reviewedBy: true,
+        reviewedAt: true,
+        createdAt: true,
+        tradeDeal: { id: true, commodity: true },
+        uploader: { id: true, email: true, role: true },
+      },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  @Post('documents/:id/verify')
+  @ApiOperation({ summary: 'Approve an uploaded document' })
+  @ApiResponse({ status: 200, description: 'Document approved' })
+  @ApiResponse({ status: 404, description: 'Document not found' })
+  async verifyDocument(@Request() req: AuthRequest, @Param('id') id: string) {
+    const document = await this.documentRepo.findOne({ where: { id } });
+    if (!document) throw new NotFoundException('Document not found');
+
+    document.verificationStatus = 'approved';
+    document.rejectionReason = null;
+    document.reviewedBy = req.user.id;
+    document.reviewedAt = new Date();
+    await this.documentRepo.save(document);
+
+    await this.adminActionRepo.save(
+      this.adminActionRepo.create({
+        adminId: req.user.id,
+        targetUserId: document.uploaderId,
+        action: 'verify_document',
+        payload: { documentId: document.id },
+        reason: null,
+      }),
+    );
+
+    return document;
+  }
+
+  @Post('documents/:id/reject')
+  @ApiOperation({ summary: 'Reject an uploaded document with a reason' })
+  @ApiBody({ type: RejectDocumentDto })
+  @ApiResponse({ status: 200, description: 'Document rejected' })
+  @ApiResponse({ status: 404, description: 'Document not found' })
+  async rejectDocument(
+    @Request() req: AuthRequest,
+    @Param('id') id: string,
+    @Body() dto: RejectDocumentDto,
+  ) {
+    const document = await this.documentRepo.findOne({ where: { id } });
+    if (!document) throw new NotFoundException('Document not found');
+
+    document.verificationStatus = 'rejected';
+    document.rejectionReason = dto.reason;
+    document.reviewedBy = req.user.id;
+    document.reviewedAt = new Date();
+    await this.documentRepo.save(document);
+
+    await this.adminActionRepo.save(
+      this.adminActionRepo.create({
+        adminId: req.user.id,
+        targetUserId: document.uploaderId,
+        action: 'reject_document',
+        payload: { documentId: document.id },
+        reason: dto.reason,
+      }),
+    );
+
+    return document;
+  }
 
   @Get('users')
   @ApiOperation({ summary: 'List all users (admin only)' })
@@ -94,7 +204,11 @@ export class AdminController {
     @Param('id') id: string,
     @Query('reason') reason?: string,
   ) {
-    return this.authService.approveCorporateKycSubmission(id, req.user.id, reason);
+    return this.authService.approveCorporateKycSubmission(
+      id,
+      req.user.id,
+      reason,
+    );
   }
 
   @Post('users/:userId/role')
@@ -105,12 +219,18 @@ export class AdminController {
     @Param('userId') userId: string,
     @Body() dto: UpdateUserRoleDto,
   ) {
-    return this.authService.updateUserRole(userId, dto.role, req.user.id, dto.reason);
+    return this.authService.updateUserRole(
+      userId,
+      dto.role,
+      req.user.id,
+      dto.reason,
+    );
   }
 
   @Post('freeze-asset')
   @ApiOperation({
-    summary: 'Freeze or unfreeze an investor trustline for a trade asset (AML compliance)',
+    summary:
+      'Freeze or unfreeze an investor trustline for a trade asset (AML compliance)',
   })
   @ApiBody({ type: FreezeAssetDto })
   @ApiResponse({

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -14,13 +14,21 @@ import { RolesGuard } from './roles.guard';
 import { QueueModule } from '../queue/queue.module';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { TradeDeal } from '../trade-deals/entities/trade-deal.entity';
+import { Document } from '../trade-deals/entities/document.entity';
 import { OfacSanctionsCheckService } from './utils/ofac-sanctions-check';
 import { LoginLog } from '../database/entities/login-log.entity';
 import { AdminAction } from '../database/entities/admin-action.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([User, KycSubmission, TradeDeal, LoginLog, AdminAction]),
+    TypeOrmModule.forFeature([
+      User,
+      KycSubmission,
+      TradeDeal,
+      Document,
+      LoginLog,
+      AdminAction,
+    ]),
     QueueModule,
     NotificationsModule,
     PassportModule,

--- a/backend/src/database/entities/admin-action.entity.ts
+++ b/backend/src/database/entities/admin-action.entity.ts
@@ -1,6 +1,17 @@
-import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+} from 'typeorm';
 
-export type AdminActionType = 'approve_kyc' | 'approve_corporate_kyc' | 'update_user_role' | 'freeze_asset';
+export type AdminActionType =
+  | 'approve_kyc'
+  | 'approve_corporate_kyc'
+  | 'update_user_role'
+  | 'freeze_asset'
+  | 'verify_document'
+  | 'reject_document';
 
 @Entity('admin_actions')
 export class AdminAction {

--- a/backend/src/database/migrations/1800000000000-AddVerificationStatusToDocuments.ts
+++ b/backend/src/database/migrations/1800000000000-AddVerificationStatusToDocuments.ts
@@ -1,0 +1,35 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddVerificationStatusToDocuments1800000000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "documents" ADD COLUMN IF NOT EXISTS "verification_status" varchar(20) NOT NULL DEFAULT 'pending'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "documents" ADD COLUMN IF NOT EXISTS "rejection_reason" text`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "documents" ADD COLUMN IF NOT EXISTS "reviewed_by" uuid`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "documents" ADD COLUMN IF NOT EXISTS "reviewed_at" TIMESTAMP WITH TIME ZONE`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "documents" DROP COLUMN IF EXISTS "reviewed_at"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "documents" DROP COLUMN IF EXISTS "reviewed_by"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "documents" DROP COLUMN IF EXISTS "rejection_reason"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "documents" DROP COLUMN IF EXISTS "verification_status"`,
+    );
+  }
+}

--- a/backend/src/trade-deals/entities/document.entity.ts
+++ b/backend/src/trade-deals/entities/document.entity.ts
@@ -58,6 +58,18 @@ export class Document {
   @Column({ name: 'metadata', type: 'jsonb', default: {} })
   metadata: DocumentMetadata;
 
+  @Column({ name: 'verification_status', length: 20, default: 'pending' })
+  verificationStatus: 'pending' | 'approved' | 'rejected';
+
+  @Column({ name: 'rejection_reason', type: 'text', nullable: true })
+  rejectionReason: string | null;
+
+  @Column({ name: 'reviewed_by', nullable: true })
+  reviewedBy: string | null;
+
+  @Column({ name: 'reviewed_at', type: 'timestamptz', nullable: true })
+  reviewedAt: Date | null;
+
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "react-dropzone": "^14.2.3",
     "react-hook-form": "^7.51.5",
     "react-leaflet": "^4.2.1",
+    "recharts": "^2.15.4",
     "zod": "^3.23.8",
     "zxcvbn": "^4.4.2"
   },

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -13,13 +13,16 @@ importers:
         version: 3.10.0(react-hook-form@7.76.1(react@18.3.1))
       '@sentry/nextjs':
         specifier: ^8.0.0
-        version: 8.55.2(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(next@14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.107.2(postcss@8.5.10))
+        version: 8.55.2(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(next@14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.107.2(postcss@8.5.10))
       '@stellar/freighter-api':
         specifier: ^2.0.0
         version: 2.0.0
       '@types/leaflet':
         specifier: ^1.9.21
         version: 1.9.21
+      '@types/zxcvbn':
+        specifier: ^4.4.4
+        version: 4.4.5
       axios:
         specifier: ^1.6.0
         version: 1.15.1
@@ -31,10 +34,10 @@ importers:
         version: 1.9.4
       next:
         specifier: ^14.0.0
-        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-intl:
         specifier: ^3.26.5
-        version: 3.26.5(next@14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        version: 3.26.5(next@14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -53,10 +56,22 @@ importers:
       react-leaflet:
         specifier: ^4.2.1
         version: 4.2.1(leaflet@1.9.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      recharts:
+        specifier: ^2.15.4
+        version: 2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       zod:
         specifier: ^3.23.8
         version: 3.25.76
+      zxcvbn:
+        specifier: ^4.4.2
+        version: 4.4.2
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.8.0
+        version: 4.12.1(playwright-core@1.61.1)
+      '@playwright/test':
+        specifier: ^1.40.0
+        version: 1.61.1
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -120,6 +135,11 @@ packages:
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@axe-core/playwright@4.12.1':
+    resolution: {integrity: sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -815,6 +835,11 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@prisma/instrumentation@5.22.0':
     resolution: {integrity: sha512-LxccF392NN37ISGxIurUljZSh1YWnphO34V5a0+T7FVQG2u9bhAXRTJpgmQ3483woVhkraQZFF7cbRrpbw/F4Q==}
 
@@ -1032,6 +1057,33 @@ packages:
   '@types/connect@3.4.36':
     resolution: {integrity: sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
@@ -1102,6 +1154,9 @@ packages:
 
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
+
+  '@types/zxcvbn@4.4.5':
+    resolution: {integrity: sha512-FZJgC5Bxuqg7Rhsm/bx6gAruHHhDQ55r+s0JhDh8CQ16fD7NsJJ+p8YMMQDhSQoIrSmjpqqYWA96oQVMNkjRyA==}
 
   '@typescript-eslint/parser@7.2.0':
     resolution: {integrity: sha512-5FKsVcHTk6TafQKQbuIVkXq58Fnbkd2wDL4LB7AURN7RUOu1utVP+G8+6u3ZhEroW3DF6hyo3ZEXxgKgp4KeCg==}
@@ -1443,6 +1498,10 @@ packages:
     resolution: {integrity: sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==}
     engines: {node: '>=4'}
 
+  axe-core@4.12.1:
+    resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
+    engines: {node: '>=4'}
+
   axios@1.15.1:
     resolution: {integrity: sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==}
 
@@ -1580,6 +1639,10 @@ packages:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
@@ -1633,6 +1696,50 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
@@ -1668,6 +1775,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
@@ -1730,6 +1840,9 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dom-helpers@5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
@@ -1937,6 +2050,9 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
@@ -1955,6 +2071,10 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-equals@5.4.1:
+    resolution: {integrity: sha512-DjlFSM5Pk9cGcL0q5QXl66eGzx0N6szNgaswwc5ZphlBohjTVJSnGgI+rJVOgOi65qUoQnDZN4nDqi33udtydQ==}
+    engines: {node: '>=6.0.0'}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -2054,6 +2174,11 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -2254,6 +2379,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   intl-messageformat@10.7.18:
     resolution: {integrity: sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==}
@@ -2668,6 +2797,9 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -2994,6 +3126,16 @@ packages:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
 
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
@@ -3134,6 +3276,18 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
 
+  react-smooth@4.0.4:
+    resolution: {integrity: sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  react-transition-group@4.4.5:
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
+
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -3144,6 +3298,17 @@ packages:
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
+
+  recharts-scale@0.4.5:
+    resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
+
+  recharts@2.15.4:
+    resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
+    engines: {node: '>=14'}
+    deprecated: 1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -3510,6 +3675,9 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
@@ -3633,6 +3801,9 @@ packages:
   v8-to-istanbul@9.3.0:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
+
+  victory-vendor@36.9.2:
+    resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
 
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -3770,6 +3941,9 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zxcvbn@4.4.2:
+    resolution: {integrity: sha512-Bq0B+ixT/DMyG8kgX2xWcI5jUvCwqrMxSFam7m0lAf78nf04hv6lNCsyLYdyYTrCVMqNDY/206K7eExYCeSyUQ==}
+
 snapshots:
 
   '@adobe/css-tools@4.4.4': {}
@@ -3783,6 +3957,11 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
+
+  '@axe-core/playwright@4.12.1(playwright-core@1.61.1)':
+    dependencies:
+      axe-core: 4.12.1
+      playwright-core: 1.61.1
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -4663,6 +4842,10 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
+
   '@prisma/instrumentation@5.22.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -4785,7 +4968,7 @@ snapshots:
 
   '@sentry/core@8.55.2': {}
 
-  '@sentry/nextjs@8.55.2(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(next@14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.107.2(postcss@8.5.10))':
+  '@sentry/nextjs@8.55.2(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(next@14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.107.2(postcss@8.5.10))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.41.1
@@ -4798,7 +4981,7 @@ snapshots:
       '@sentry/vercel-edge': 8.55.2
       '@sentry/webpack-plugin': 2.22.7(webpack@5.107.2(postcss@8.5.10))
       chalk: 3.0.0
-      next: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       resolve: 1.22.8
       rollup: 3.29.5
       stacktrace-parser: 0.1.11
@@ -4969,6 +5152,30 @@ snapshots:
     dependencies:
       '@types/node': 20.19.39
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/estree@1.0.9': {}
 
   '@types/geojson@7946.0.16': {}
@@ -5046,6 +5253,8 @@ snapshots:
   '@types/yargs@17.0.35':
     dependencies:
       '@types/yargs-parser': 21.0.3
+
+  '@types/zxcvbn@4.4.5': {}
 
   '@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
@@ -5402,6 +5611,8 @@ snapshots:
 
   axe-core@4.11.3: {}
 
+  axe-core@4.12.1: {}
+
   axios@1.15.1:
     dependencies:
       follow-redirects: 1.16.0
@@ -5568,6 +5779,8 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
+  clsx@2.1.1: {}
+
   co@4.6.0: {}
 
   collect-v8-coverage@1.0.3: {}
@@ -5609,6 +5822,44 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   damerau-levenshtein@1.0.8: {}
 
   data-urls@5.0.0:
@@ -5641,6 +5892,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   decimal.js@10.6.0: {}
 
@@ -5687,6 +5940,11 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dom-helpers@5.2.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      csstype: 3.2.3
 
   dotenv@16.6.1: {}
 
@@ -6032,6 +6290,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventemitter3@4.0.7: {}
+
   events@3.3.0: {}
 
   execa@5.1.1:
@@ -6058,6 +6318,8 @@ snapshots:
       jest-util: 30.3.0
 
   fast-deep-equal@3.1.3: {}
+
+  fast-equals@5.4.1: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -6148,6 +6410,9 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
 
   fs.realpath@1.0.0: {}
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -6366,6 +6631,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.3
       side-channel: 1.1.0
+
+  internmap@2.0.3: {}
 
   intl-messageformat@10.7.18:
     dependencies:
@@ -6988,6 +7255,8 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  lodash@4.18.1: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -7087,11 +7356,11 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next-intl@3.26.5(next@14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
+  next-intl@3.26.5(next@14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
     dependencies:
       '@formatjs/intl-localematcher': 0.5.10
       negotiator: 1.0.0
-      next: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       use-intl: 3.26.5(react@18.3.1)
 
@@ -7100,7 +7369,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  next@14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.35
       '@swc/helpers': 0.5.5
@@ -7122,6 +7391,7 @@ snapshots:
       '@next/swc-win32-ia32-msvc': 14.2.33
       '@next/swc-win32-x64-msvc': 14.2.33
       '@opentelemetry/api': 1.9.1
+      '@playwright/test': 1.61.1
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -7292,6 +7562,14 @@ snapshots:
     dependencies:
       find-up: 4.1.0
 
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
   possible-typed-array-names@1.1.0: {}
 
   postcss-import@15.1.0(postcss@8.5.10):
@@ -7409,6 +7687,23 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  react-smooth@4.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      fast-equals: 5.4.1
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+
+  react-transition-group@4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.29.2
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
@@ -7420,6 +7715,23 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.2
+
+  recharts-scale@0.4.5:
+    dependencies:
+      decimal.js-light: 2.5.1
+
+  recharts@2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      clsx: 2.1.1
+      eventemitter3: 4.0.7
+      lodash: 4.18.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-is: 18.3.1
+      react-smooth: 4.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      recharts-scale: 0.4.5
+      tiny-invariant: 1.3.3
+      victory-vendor: 36.9.2
 
   redent@3.0.0:
     dependencies:
@@ -7826,6 +8138,8 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tiny-invariant@1.3.3: {}
+
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
@@ -7980,6 +8294,23 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
+
+  victory-vendor@36.9.2:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   w3c-xmlserializer@5.0.0:
     dependencies:
@@ -8150,3 +8481,5 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zod@3.25.76: {}
+
+  zxcvbn@4.4.2: {}

--- a/frontend/src/app/[locale]/dashboard/admin/documents/page.tsx
+++ b/frontend/src/app/[locale]/dashboard/admin/documents/page.tsx
@@ -1,0 +1,332 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { apiClient, User, getStoredToken } from '@/lib/api';
+import DashboardLayout from '@/components/DashboardLayout';
+import { PdfViewer } from '@/components/ui/PdfViewer';
+import { useToast } from '@/components/ui/ToastProvider';
+
+interface AdminDocument {
+  id: string;
+  tradeDealId: string;
+  uploaderId: string;
+  docType: string;
+  ipfsHash: string;
+  storageUrl: string;
+  stellarTxId: string | null;
+  signatureVerified: boolean;
+  verificationStatus: 'pending' | 'approved' | 'rejected';
+  rejectionReason: string | null;
+  reviewedAt: string | null;
+  createdAt: string;
+  tradeDeal: { id: string; commodity: string } | null;
+  uploader: { id: string; email: string; role: string } | null;
+}
+
+const STATUS_BADGE: Record<string, string> = {
+  pending: 'badge-yellow',
+  approved: 'badge-green',
+  rejected: 'badge-red',
+};
+
+function docLabel(type: string) {
+  return type.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function isPdf(url: string) {
+  return url.toLowerCase().includes('.pdf') || url.toLowerCase().includes('application/pdf');
+}
+
+type StatusFilter = 'pending' | 'approved' | 'rejected' | 'all';
+
+export default function AdminDocumentsPage() {
+  const router = useRouter();
+  const { toast } = useToast();
+
+  const [user, setUser] = useState<User | null>(null);
+  const [docs, setDocs] = useState<AdminDocument[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('pending');
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [actionLoading, setActionLoading] = useState(false);
+  const [showRejectForm, setShowRejectForm] = useState(false);
+  const [rejectReason, setRejectReason] = useState('');
+
+  useEffect(() => {
+    (async () => {
+      const cached = apiClient.getCurrentUser();
+      if (!cached) { router.push('/login'); return; }
+      let u = cached;
+      try { const f = await apiClient.refreshCurrentUser(); if (f) u = f; } catch {}
+      if (u.role !== 'admin') { router.push(`/dashboard/${u.role}`); return; }
+      setUser(u);
+      await loadDocuments();
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [router]);
+
+  const loadDocuments = async () => {
+    setLoading(true);
+    try {
+      const token = getStoredToken();
+      const res = await fetch('/api/admin/documents', { headers: { Authorization: `Bearer ${token}` } });
+      if (res.ok) {
+        const d = await res.json();
+        setDocs(Array.isArray(d) ? d : d.data ?? []);
+      }
+    } catch {}
+    setLoading(false);
+  };
+
+  const filtered = docs.filter((d) => statusFilter === 'all' || d.verificationStatus === statusFilter);
+  const selected = docs.find((d) => d.id === selectedId) ?? filtered[0] ?? null;
+  const pendingCount = docs.filter((d) => d.verificationStatus === 'pending').length;
+
+  const selectDoc = (id: string) => {
+    setSelectedId(id);
+    setShowRejectForm(false);
+    setRejectReason('');
+  };
+
+  const approve = async () => {
+    if (!selected) return;
+    setActionLoading(true);
+    try {
+      const token = getStoredToken();
+      const res = await fetch(`/api/admin/documents/${selected.id}/verify`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.ok) {
+        toast('Document approved ✅', 'success');
+        await loadDocuments();
+      } else {
+        const d = await res.json();
+        toast(d.message ?? 'Failed to approve document', 'error');
+      }
+    } catch {
+      toast('Request failed', 'error');
+    }
+    setActionLoading(false);
+  };
+
+  const reject = async () => {
+    if (!selected || rejectReason.trim().length < 3) {
+      toast('Please provide a rejection reason', 'error');
+      return;
+    }
+    setActionLoading(true);
+    try {
+      const token = getStoredToken();
+      const res = await fetch(`/api/admin/documents/${selected.id}/reject`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reason: rejectReason.trim() }),
+      });
+      if (res.ok) {
+        toast('Document rejected', 'success');
+        setShowRejectForm(false);
+        setRejectReason('');
+        await loadDocuments();
+      } else {
+        const d = await res.json();
+        toast(d.message ?? 'Failed to reject document', 'error');
+      }
+    } catch {
+      toast('Request failed', 'error');
+    }
+    setActionLoading(false);
+  };
+
+  if (!user) return null;
+
+  return (
+    <DashboardLayout user={user}>
+      <div className="page-content">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="text-sm text-slate-500 mb-1">Document verification</p>
+            <h1 className="page-title">Verify Documents</h1>
+          </div>
+          {pendingCount > 0 && (
+            <span className="badge-yellow">{pendingCount} pending</span>
+          )}
+        </div>
+
+        {/* Status filter tabs */}
+        <div className="flex gap-1 bg-slate-100 rounded-xl p-1 w-fit">
+          {(['pending', 'approved', 'rejected', 'all'] as StatusFilter[]).map((s) => (
+            <button
+              key={s}
+              onClick={() => setStatusFilter(s)}
+              className={`px-4 py-2 rounded-lg text-sm font-semibold capitalize transition-all ${
+                statusFilter === s ? 'bg-white shadow-sm text-slate-900' : 'text-slate-500 hover:text-slate-700'
+              }`}
+            >
+              {s}
+            </button>
+          ))}
+        </div>
+
+        {loading ? (
+          <div className="grid lg:grid-cols-[340px_1fr] gap-5">
+            <div className="card h-96 skeleton" />
+            <div className="card h-96 skeleton" />
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="card p-14 text-center">
+            <div className="w-16 h-16 rounded-3xl bg-emerald-50 flex items-center justify-center text-3xl mx-auto mb-5">
+              {statusFilter === 'pending' ? '✅' : '📂'}
+            </div>
+            <h3 className="font-bold text-slate-900 text-lg mb-2">
+              {statusFilter === 'pending' ? 'All clear!' : 'No documents found'}
+            </h3>
+            <p className="text-slate-500 text-sm">
+              {statusFilter === 'pending'
+                ? 'No documents are waiting for verification.'
+                : `No documents with status "${statusFilter}".`}
+            </p>
+          </div>
+        ) : (
+          <div className="grid lg:grid-cols-[340px_1fr] gap-5 items-start">
+            {/* List */}
+            <div className="table-wrapper divide-y divide-border max-h-[720px] overflow-y-auto">
+              {filtered.map((doc) => (
+                <button
+                  key={doc.id}
+                  onClick={() => selectDoc(doc.id)}
+                  className={`w-full text-left px-4 py-3.5 flex items-start gap-3 transition-colors hover:bg-neutral-muted/50 ${
+                    selected?.id === doc.id ? 'bg-neutral-muted/70' : ''
+                  }`}
+                >
+                  <div className="w-9 h-9 rounded-xl bg-red-50 flex items-center justify-center text-lg flex-shrink-0">
+                    📄
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-semibold text-slate-900 truncate">{docLabel(doc.docType)}</p>
+                    <p className="text-xs text-slate-400 truncate">
+                      {doc.uploader?.email ?? 'Unknown uploader'}
+                      {doc.tradeDeal?.commodity ? ` · ${doc.tradeDeal.commodity}` : ''}
+                    </p>
+                    <div className="flex items-center gap-2 mt-1.5">
+                      <span className={STATUS_BADGE[doc.verificationStatus] ?? 'badge-gray'}>
+                        {doc.verificationStatus}
+                      </span>
+                      <span className="text-[11px] text-slate-400">
+                        {new Date(doc.createdAt).toLocaleDateString()}
+                      </span>
+                    </div>
+                  </div>
+                </button>
+              ))}
+            </div>
+
+            {/* Detail */}
+            {selected && (
+              <div className="space-y-4">
+                <div className="card p-5">
+                  <div className="flex items-start justify-between gap-4 flex-wrap">
+                    <div>
+                      <h2 className="font-bold text-slate-900 text-lg">{docLabel(selected.docType)}</h2>
+                      <p className="text-sm text-slate-500 mt-0.5">
+                        Submitted by <span className="font-medium text-slate-700">{selected.uploader?.email ?? 'Unknown'}</span>
+                        {selected.tradeDeal?.commodity && (
+                          <> for <span className="font-medium text-slate-700 capitalize">{selected.tradeDeal.commodity}</span></>
+                        )}
+                      </p>
+                      <p className="text-xs text-slate-400 mt-1">
+                        Uploaded {new Date(selected.createdAt).toLocaleString()}
+                        {selected.signatureVerified && ' · ✅ Signature verified'}
+                      </p>
+                    </div>
+                    <span className={STATUS_BADGE[selected.verificationStatus] ?? 'badge-gray'}>
+                      {selected.verificationStatus}
+                    </span>
+                  </div>
+
+                  {selected.verificationStatus === 'rejected' && selected.rejectionReason && (
+                    <div className="alert-error mt-4">
+                      <span>⚠</span>
+                      <p><strong>Rejection reason:</strong> {selected.rejectionReason}</p>
+                    </div>
+                  )}
+                </div>
+
+                {/* Document preview */}
+                {isPdf(selected.storageUrl) ? (
+                  <PdfViewer url={selected.storageUrl} fileName={`${docLabel(selected.docType)}.pdf`} />
+                ) : (
+                  <div className="card p-4">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={selected.storageUrl}
+                      alt={docLabel(selected.docType)}
+                      className="max-h-[500px] w-full object-contain rounded-xl bg-slate-50"
+                    />
+                  </div>
+                )}
+
+                {/* Verification panel */}
+                {selected.verificationStatus === 'pending' && (
+                  <div className="card p-5 space-y-4">
+                    <h3 className="font-semibold text-slate-900 text-sm">Verification decision</h3>
+
+                    {!showRejectForm ? (
+                      <div className="flex gap-3">
+                        <button
+                          onClick={approve}
+                          disabled={actionLoading}
+                          className="btn-primary flex-1"
+                        >
+                          {actionLoading ? 'Approving…' : '✓ Approve'}
+                        </button>
+                        <button
+                          onClick={() => setShowRejectForm(true)}
+                          disabled={actionLoading}
+                          className="btn-danger flex-1"
+                        >
+                          ✕ Reject
+                        </button>
+                      </div>
+                    ) : (
+                      <div className="space-y-3">
+                        <div>
+                          <label htmlFor="rejection-reason" className="label">Rejection reason</label>
+                          <textarea
+                            id="rejection-reason"
+                            className="textarea"
+                            rows={3}
+                            placeholder="Explain why this document is being rejected…"
+                            value={rejectReason}
+                            onChange={(e) => setRejectReason(e.target.value)}
+                          />
+                        </div>
+                        <div className="flex gap-3">
+                          <button
+                            onClick={reject}
+                            disabled={actionLoading || rejectReason.trim().length < 3}
+                            className="btn-danger flex-1"
+                          >
+                            {actionLoading ? 'Submitting…' : 'Confirm Rejection'}
+                          </button>
+                          <button
+                            onClick={() => { setShowRejectForm(false); setRejectReason(''); }}
+                            disabled={actionLoading}
+                            className="btn-secondary flex-1"
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/frontend/src/app/[locale]/dashboard/investor/page.tsx
+++ b/frontend/src/app/[locale]/dashboard/investor/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { apiClient, Investment, User } from '../../../../lib/api';
@@ -8,6 +8,7 @@ import DashboardLayout from '../../../../components/DashboardLayout';
 import StatCard from '../../../../components/StatCard';
 import { InvestmentCertificate } from '../../../../components/InvestmentCertificate';
 import { AnchorWidget } from '../../../../components/AnchorWidget';
+import PortfolioChart from '../../../../components/dashboard/PortfolioChart';
 
 const INV_STATUS: Record<string, string> = {
   confirmed: 'badge-green', pending: 'badge-yellow', failed: 'badge-red', refunded: 'badge-gray',
@@ -60,6 +61,20 @@ export default function InvestorDashboard() {
 
   const filtered = filter === 'all' ? investments
     : investments.filter(i => i.status === filter);
+
+  // Derive a portfolio-value-over-time trend from confirmed investments —
+  // running total of invested capital, ordered by when each was made.
+  const portfolioHistory = useMemo(() => {
+    let running = 0;
+    return investments
+      .filter(i => i.status === 'confirmed')
+      .slice()
+      .sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime())
+      .map(i => {
+        running += Number(i.amount_invested);
+        return { date: i.created_at, value: running };
+      });
+  }, [investments]);
 
   const confirmedInvestments = investments.filter(i => i.status === 'confirmed');
 
@@ -123,6 +138,10 @@ export default function InvestorDashboard() {
         {/* ── Portfolio tab ── */}
         {tab === 'portfolio' && (
           <>
+            {!loading && investments.length > 0 && (
+              <PortfolioChart data={portfolioHistory} />
+            )}
+
             {investments.length > 0 && (
               <div className="flex gap-1 bg-slate-100 rounded-xl p-1 w-fit">
                 {(['all', 'confirmed', 'pending'] as const).map(f => (

--- a/frontend/src/app/[locale]/help/page.tsx
+++ b/frontend/src/app/[locale]/help/page.tsx
@@ -1,0 +1,316 @@
+'use client';
+
+/**
+ * Help Center
+ *
+ * Public educational page for farmers and investors who are new to
+ * blockchain / tokenized trade finance. No authentication required.
+ */
+
+import Link from 'next/link';
+import { useMemo, useState } from 'react';
+
+interface FaqItem {
+  q: string;
+  a: string;
+}
+
+interface FaqCategory {
+  key: string;
+  label: string;
+  icon: string;
+  items: FaqItem[];
+}
+
+const CATEGORIES: FaqCategory[] = [
+  {
+    key: 'stellar',
+    label: 'Stellar',
+    icon: '⭐',
+    items: [
+      {
+        q: 'What is Stellar and why does AgriFi use it?',
+        a: 'Stellar is a public blockchain built for fast, low-cost payments. AgriFi uses it to move USDC between investors and farmers in seconds, for a fraction of a cent in fees, and to record every transaction on a public ledger anyone can verify.',
+      },
+      {
+        q: 'What is Soroban?',
+        a: "Soroban is Stellar's smart contract platform. AgriFi's \"FarmCampaign\" contracts automatically hold investor funds in escrow, release payment milestones as a shipment progresses, and split revenue among investors — no manual bank transfers involved.",
+      },
+      {
+        q: 'What is a Stellar wallet and how do I get one?',
+        a: 'A wallet is where you hold your Stellar assets (USDC and trade tokens) and sign transactions. We support Freighter, a free browser extension wallet — install it, create an account, and click "Connect Wallet" from your dashboard.',
+      },
+      {
+        q: 'What are trustlines?',
+        a: 'A trustline is a Stellar account setting that says "I am willing to hold this specific asset." Before you can receive USDC or a deal\'s trade token, your wallet needs a trustline to it — AgriFi prompts you to add one automatically the first time you need it.',
+      },
+    ],
+  },
+  {
+    key: 'investing',
+    label: 'Investing',
+    icon: '💼',
+    items: [
+      {
+        q: 'How do I invest in a deal?',
+        a: 'Browse open deals in the Marketplace, choose how many tokens you want to buy, and confirm the investment. You\'ll sign a Stellar transaction in your wallet that sends USDC into the deal\'s escrow contract in exchange for trade tokens.',
+      },
+      {
+        q: 'What is the minimum investment amount?',
+        a: 'Each deal sets its own token price (fixed at $100 per token), so the minimum is the price of a single token. Some deals may set a higher minimum token purchase — check the deal page for details.',
+      },
+      {
+        q: 'How are returns calculated and paid out?',
+        a: 'Your expected return is based on the deal\'s annual ROI and term length, shown on every deal card. Once the commodity is delivered and sold, revenue is distributed on-chain to all token holders proportional to their holdings.',
+      },
+      {
+        q: 'Can I sell my investment before maturity?',
+        a: 'Yes — trade tokens can be listed on the Stellar DEX secondary market from your Investor Dashboard, letting other investors buy your position before the deal completes.',
+      },
+      {
+        q: 'What happens if a deal fails to reach its funding target?',
+        a: "If a deal doesn't reach its funding target by the deadline, the smart contract can be marked failed and invested funds are returned to investors' wallets.",
+      },
+    ],
+  },
+  {
+    key: 'shipping',
+    label: 'Shipping',
+    icon: '🚚',
+    items: [
+      {
+        q: "How is my commodity's shipment tracked?",
+        a: 'Every deal moves through four recorded milestones — Farm, Warehouse, Port, and Importer — each logged on-chain with a timestamp and optional notes, so you can follow the shipment in real time from the deal page.',
+      },
+      {
+        q: 'What documents are uploaded during shipping?',
+        a: 'Farmers and traders upload supporting documents such as bills of lading, export certificates, quality certificates, and warehouse receipts. Each document is stored on IPFS and anchored with a Stellar transaction so it can never be silently altered.',
+      },
+      {
+        q: 'What happens if a shipment is delayed?',
+        a: "If a deal passes its delivery date without reaching the \"delivered\" milestone, it's flagged as delayed on your Investor Dashboard so you can monitor it closely and reach out to platform admins if needed.",
+      },
+      {
+        q: 'Who records the milestones?',
+        a: 'The farmer or trader responsible for the deal records each milestone as the shipment physically progresses. This creates an auditable, tamper-evident trail from farm gate to final delivery.',
+      },
+    ],
+  },
+  {
+    key: 'security',
+    label: 'Security',
+    icon: '🔒',
+    items: [
+      {
+        q: 'How is my money protected?',
+        a: "Investor funds are held in a Soroban escrow smart contract, not by AgriFi directly. Funds only move according to the contract's programmed rules — released to the farmer on verified milestones, or returned to investors if a deal fails.",
+      },
+      {
+        q: 'Is my personal data safe?',
+        a: 'Personal and KYC data is encrypted at rest and only accessible to platform admins for compliance review. Blockchain records only contain financial transactions and document hashes — never personal information.',
+      },
+      {
+        q: 'What is KYC and why is it required?',
+        a: "KYC (Know Your Customer) verifies your identity before you can invest or list a deal. It's a regulatory requirement that protects the platform and its users from fraud and money laundering.",
+      },
+      {
+        q: 'How are documents verified on-chain?',
+        a: "Every uploaded document is hashed and the hash is anchored in a Stellar transaction. Admins can also verify an attached cryptographic signature. This means a document's authenticity and upload time can be independently confirmed by anyone, at any time.",
+      },
+    ],
+  },
+];
+
+const LIFECYCLE_STEPS = [
+  { step: '1', label: 'Deal Listed', desc: 'A farmer or trader lists a commodity deal with quantity, price, and delivery date.', icon: '📝' },
+  { step: '2', label: 'Investors Fund', desc: 'Investors buy trade tokens with USDC; funds are held in a Soroban escrow contract.', icon: '💰' },
+  { step: '3', label: 'Shipment Tracked', desc: 'Milestones are recorded on-chain as the commodity moves: Farm → Warehouse → Port → Importer.', icon: '🚚' },
+  { step: '4', label: 'Delivery Confirmed', desc: 'The buyer confirms receipt and the deal is marked delivered.', icon: '📦' },
+  { step: '5', label: 'Revenue Distributed', desc: 'Sale proceeds are distributed on-chain to investors proportional to their token holdings.', icon: '🏆' },
+];
+
+function highlight(text: string, query: string) {
+  if (!query.trim()) return text;
+  const idx = text.toLowerCase().indexOf(query.toLowerCase());
+  if (idx === -1) return text;
+  return (
+    <>
+      {text.slice(0, idx)}
+      <mark className="bg-amber-200 text-inherit rounded-sm px-0.5">
+        {text.slice(idx, idx + query.length)}
+      </mark>
+      {text.slice(idx + query.length)}
+    </>
+  );
+}
+
+export default function HelpPage() {
+  const [search, setSearch] = useState('');
+  const [openKey, setOpenKey] = useState<string | null>(null);
+
+  const filteredCategories = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return CATEGORIES;
+    return CATEGORIES.map((cat) => ({
+      ...cat,
+      items: cat.items.filter(
+        (item) => item.q.toLowerCase().includes(q) || item.a.toLowerCase().includes(q)
+      ),
+    })).filter((cat) => cat.items.length > 0);
+  }, [search]);
+
+  const totalMatches = filteredCategories.reduce((sum, c) => sum + c.items.length, 0);
+  const isSearching = search.trim().length > 0;
+
+  const toggle = (id: string) => setOpenKey((current) => (current === id ? null : id));
+
+  return (
+    <main className="min-h-screen bg-canvas py-12 px-4">
+      <div className="max-w-4xl mx-auto space-y-10">
+        {/* Top bar */}
+        <div className="flex items-center justify-between">
+          <Link href="/" className="flex items-center gap-2.5 group">
+            <span className="text-2xl group-hover:animate-bounce-sm transition-transform">🌾</span>
+            <span className="font-black text-slate-900 text-lg tracking-tight">AgriFi</span>
+          </Link>
+          <Link href="/marketplace" className="btn-secondary text-sm">
+            Browse Marketplace
+          </Link>
+        </div>
+
+        {/* Header */}
+        <div className="text-center space-y-3">
+          <h1 className="page-title text-3xl md:text-4xl">Help Center</h1>
+          <p className="text-slate-500 max-w-xl mx-auto">
+            New to blockchain or tokenized trade finance? Everything you need to know
+            about investing, shipping, and staying secure on AgriFi.
+          </p>
+        </div>
+
+        {/* Search */}
+        <div className="relative max-w-lg mx-auto">
+          <span className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400">
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+            </svg>
+          </span>
+          <input
+            type="search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search questions… e.g. wallet, escrow, KYC"
+            aria-label="Search help questions"
+            className="input pl-10"
+          />
+          {isSearching && (
+            <p className="text-xs text-slate-400 mt-2 text-center">
+              {totalMatches} result{totalMatches === 1 ? '' : 's'} for &ldquo;{search}&rdquo;
+            </p>
+          )}
+        </div>
+
+        {/* Deal lifecycle diagram */}
+        <div className="card p-6">
+          <h2 className="section-title mb-6 text-center">How a Deal Works</h2>
+          <div className="flex flex-col md:flex-row md:items-start gap-4">
+            {LIFECYCLE_STEPS.map((s, i) => (
+              <div key={s.step} className="flex md:flex-col flex-1 items-start md:items-center gap-4 md:gap-3 relative">
+                <div className="flex flex-col items-center flex-shrink-0">
+                  <div className="w-12 h-12 rounded-2xl bg-primary text-primary-foreground flex items-center justify-center text-xl shadow-sm">
+                    {s.icon}
+                  </div>
+                  {i < LIFECYCLE_STEPS.length - 1 && (
+                    <>
+                      {/* connector: vertical on mobile, horizontal on desktop */}
+                      <div className="w-0.5 flex-1 bg-border md:hidden mt-1" style={{ minHeight: '1.5rem' }} />
+                    </>
+                  )}
+                </div>
+                {i < LIFECYCLE_STEPS.length - 1 && (
+                  <div className="hidden md:block absolute top-6 left-[calc(50%+1.5rem)] right-[calc(-50%+1.5rem)] h-0.5 bg-border" />
+                )}
+                <div className="md:text-center">
+                  <p className="text-sm font-bold text-slate-900">{s.label}</p>
+                  <p className="text-xs text-slate-500 mt-1 md:px-1">{s.desc}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* FAQ categories */}
+        <div className="space-y-8">
+          {filteredCategories.length === 0 && (
+            <div className="card p-12 text-center">
+              <div className="w-14 h-14 rounded-2xl bg-slate-100 flex items-center justify-center text-2xl mx-auto mb-3">
+                🔍
+              </div>
+              <p className="text-sm font-semibold text-slate-700">No questions match &ldquo;{search}&rdquo;</p>
+              <p className="text-xs text-slate-400 mt-1">Try a different keyword, or browse all categories below.</p>
+              <button onClick={() => setSearch('')} className="btn-secondary text-sm mt-4">
+                Clear search
+              </button>
+            </div>
+          )}
+
+          {filteredCategories.map((cat) => (
+            <section key={cat.key}>
+              <h2 className="flex items-center gap-2 section-title mb-3">
+                <span className="text-xl">{cat.icon}</span>
+                {cat.label}
+                <span className="text-xs font-normal text-slate-400">({cat.items.length})</span>
+              </h2>
+
+              <div className="card divide-y divide-border overflow-hidden">
+                {cat.items.map((item, i) => {
+                  const id = `${cat.key}-${i}`;
+                  const isOpen = isSearching || openKey === id;
+                  return (
+                    <div key={id}>
+                      <button
+                        type="button"
+                        onClick={() => toggle(id)}
+                        aria-expanded={isOpen}
+                        aria-controls={`${id}-panel`}
+                        className="w-full flex items-center justify-between gap-4 px-5 py-4 text-left hover:bg-neutral-muted/50 transition-colors"
+                      >
+                        <span className="text-sm font-semibold text-slate-900">
+                          {highlight(item.q, search)}
+                        </span>
+                        <svg
+                          className={`w-4 h-4 text-slate-400 flex-shrink-0 transition-transform ${isOpen ? 'rotate-180' : ''}`}
+                          fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24"
+                        >
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+                        </svg>
+                      </button>
+                      {isOpen && (
+                        <div id={`${id}-panel`} className="px-5 pb-4 -mt-1">
+                          <p className="text-sm text-slate-600 leading-relaxed">
+                            {highlight(item.a, search)}
+                          </p>
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
+          ))}
+        </div>
+
+        {/* Still need help */}
+        <div className="card p-6 text-center bg-neutral-muted/40">
+          <p className="text-sm font-semibold text-slate-900">Still have questions?</p>
+          <p className="text-xs text-slate-500 mt-1">
+            Reach out to your account admin, or check the{' '}
+            <Link href="/transparency" className="text-primary hover:underline font-medium">
+              transparency page
+            </Link>{' '}
+            to verify any deal on-chain.
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/api/admin/documents/[id]/reject/route.ts
+++ b/frontend/src/app/api/admin/documents/[id]/reject/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { fetchBackend } from '@/config/backend';
+
+export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const authHeader = request.headers.get('authorization');
+    const body = await request.json();
+    const response = await fetchBackend(`/admin/documents/${params.id}/reject`, {
+      method: 'POST',
+      headers: { Authorization: authHeader || '', 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const data = await response.json();
+    if (!response.ok) return NextResponse.json(data, { status: response.status });
+    return NextResponse.json(data);
+  } catch (error: any) {
+    if (error?.isBackendUnreachable)
+      return NextResponse.json({ message: 'Backend service is unavailable' }, { status: 503 });
+    return NextResponse.json({ message: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/frontend/src/app/api/admin/documents/[id]/verify/route.ts
+++ b/frontend/src/app/api/admin/documents/[id]/verify/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { fetchBackend } from '@/config/backend';
+
+export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const authHeader = request.headers.get('authorization');
+    const response = await fetchBackend(`/admin/documents/${params.id}/verify`, {
+      method: 'POST',
+      headers: { Authorization: authHeader || '', 'Content-Type': 'application/json' },
+    });
+    const data = await response.json();
+    if (!response.ok) return NextResponse.json(data, { status: response.status });
+    return NextResponse.json(data);
+  } catch (error: any) {
+    if (error?.isBackendUnreachable)
+      return NextResponse.json({ message: 'Backend service is unavailable' }, { status: 503 });
+    return NextResponse.json({ message: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/frontend/src/app/api/admin/documents/route.ts
+++ b/frontend/src/app/api/admin/documents/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { fetchBackend } from '@/config/backend';
+
+export async function GET(request: NextRequest) {
+  try {
+    const authHeader = request.headers.get('authorization');
+    const status = request.nextUrl.searchParams.get('status');
+    const query = status ? `?status=${encodeURIComponent(status)}` : '';
+    const response = await fetchBackend(`/admin/documents${query}`, {
+      headers: { Authorization: authHeader || '' },
+    });
+    const data = await response.json();
+    if (!response.ok) return NextResponse.json(data, { status: response.status });
+    return NextResponse.json(data);
+  } catch (error: any) {
+    if (error?.isBackendUnreachable)
+      return NextResponse.json({ message: 'Backend service is unavailable' }, { status: 503 });
+    return NextResponse.json({ message: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -377,6 +377,24 @@
   border-radius: inherit;
 }
 
+/* ── Portfolio chart — Issue #273 ─────────────────────────────────────────── */
+.portfolio-chart {
+  --chart-grid: #f1f5f9;
+  --chart-axis: #94a3b8;
+  --chart-line: #16a34a;
+}
+html.dark .portfolio-chart {
+  --chart-grid: #1e293b;
+  --chart-axis: #64748b;
+  --chart-line: #4ade80;
+}
+.portfolio-chart-tooltip {
+  @apply rounded-xl border border-slate-200 bg-white px-3.5 py-2.5 shadow-card-md;
+}
+html.dark .portfolio-chart-tooltip {
+  @apply border-slate-700 bg-slate-900;
+}
+
 /* ── Leaflet map — Issue #247 ─────────────────────────────────────────────── */
 /* Prevent Leaflet controls from inheriting global styles and breaking layout */
 .leaflet-container {

--- a/frontend/src/components/DashboardLayout.tsx
+++ b/frontend/src/components/DashboardLayout.tsx
@@ -23,6 +23,7 @@ const investorNav: NavItem[] = [
 ];
 const adminNav: NavItem[] = [
   { label: 'Dashboard',   href: '/dashboard/admin',   icon: <HomeIcon />,   exact: true },
+  { label: 'Verify Documents', href: '/dashboard/admin/documents', icon: <DocsIcon /> },
   { label: 'Marketplace', href: '/marketplace',        icon: <ShopIcon /> },
 ];
 

--- a/frontend/src/components/dashboard/PortfolioChart.tsx
+++ b/frontend/src/components/dashboard/PortfolioChart.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import {
+  ResponsiveContainer,
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  TooltipProps,
+} from 'recharts';
+
+export interface PortfolioHistoryPoint {
+  /** ISO date string */
+  date: string;
+  /** Portfolio value (USD) at that date */
+  value: number;
+}
+
+interface PortfolioChartProps {
+  /**
+   * Raw history payload from the API. Accepts a loose shape so callers don't
+   * need to pre-normalize field names — see `formatPortfolioHistory`.
+   */
+  data: unknown;
+  loading?: boolean;
+  className?: string;
+}
+
+/**
+ * Normalizes a raw API history response into a sorted coordinates array.
+ * Tolerates a few common field-naming conventions (snake_case / camelCase)
+ * and silently drops entries that can't be parsed into a valid point.
+ */
+export function formatPortfolioHistory(raw: unknown): PortfolioHistoryPoint[] {
+  if (!Array.isArray(raw)) return [];
+
+  return raw
+    .map((entry): PortfolioHistoryPoint | null => {
+      if (!entry || typeof entry !== 'object') return null;
+      const record = entry as Record<string, unknown>;
+
+      const rawDate =
+        record.date ?? record.recordedAt ?? record.recorded_at ??
+        record.timestamp ?? record.createdAt ?? record.created_at;
+      const rawValue =
+        record.value ?? record.portfolioValue ?? record.portfolio_value ??
+        record.totalValue ?? record.total_value ?? record.amount;
+
+      if (rawDate == null || rawValue == null) return null;
+
+      const date = new Date(rawDate as string | number);
+      const value = Number(rawValue);
+      if (Number.isNaN(date.getTime()) || !Number.isFinite(value)) return null;
+
+      return { date: date.toISOString(), value };
+    })
+    .filter((point): point is PortfolioHistoryPoint => point !== null)
+    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+}
+
+const currency = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  maximumFractionDigits: 0,
+});
+const currencyCompact = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  notation: 'compact',
+  maximumFractionDigits: 1,
+});
+
+function formatAxisDate(iso: string) {
+  return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+function formatFullDate(iso: string) {
+  return new Date(iso).toLocaleDateString(undefined, { month: 'long', day: 'numeric', year: 'numeric' });
+}
+
+function ChartTooltip({ active, payload, label }: TooltipProps<number, string>) {
+  if (!active || !payload?.length) return null;
+  const value = payload[0]?.value;
+  if (typeof value !== 'number') return null;
+
+  return (
+    <div className="portfolio-chart-tooltip">
+      <p className="text-sm font-bold text-slate-900 dark:text-slate-100 tabular-nums">
+        {currency.format(value)}
+      </p>
+      <p className="text-xs text-slate-400 mt-0.5 flex items-center gap-1.5">
+        <span className="inline-block w-2.5 h-0.5 rounded-full" style={{ backgroundColor: 'var(--chart-line)' }} />
+        {formatFullDate(String(label))}
+      </p>
+    </div>
+  );
+}
+
+export default function PortfolioChart({ data, loading = false, className = '' }: PortfolioChartProps) {
+  const points = useMemo(() => formatPortfolioHistory(data), [data]);
+
+  if (loading) {
+    return (
+      <div className={`card p-5 ${className}`}>
+        <div className="h-4 w-40 skeleton rounded mb-6" />
+        <div className="h-64 w-full skeleton rounded-xl" />
+      </div>
+    );
+  }
+
+  if (points.length < 2) {
+    return (
+      <div className={`card p-8 flex flex-col items-center justify-center text-center gap-2 h-[320px] ${className}`}>
+        <div className="w-12 h-12 rounded-2xl bg-slate-100 flex items-center justify-center text-2xl">
+          📈
+        </div>
+        <p className="text-sm font-semibold text-slate-700">Not enough history yet</p>
+        <p className="text-xs text-slate-400 max-w-[220px]">
+          {points.length === 1
+            ? `Your current portfolio value is ${currency.format(points[0].value)}. Check back after your next investment to see a trend.`
+            : 'Once you have investment activity, your portfolio trend will appear here.'}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`portfolio-chart card p-5 ${className}`}>
+      <div className="flex items-center justify-between mb-1">
+        <h3 className="section-title text-base">Portfolio Value</h3>
+        <span className="text-xs font-semibold text-slate-400">
+          {formatAxisDate(points[0].date)} – {formatAxisDate(points[points.length - 1].date)}
+        </span>
+      </div>
+
+      <ResponsiveContainer width="100%" height={280}>
+        <AreaChart data={points} margin={{ top: 16, right: 8, left: 0, bottom: 0 }}>
+          <defs>
+            <linearGradient id="portfolioValueFill" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="var(--chart-line)" stopOpacity={0.18} />
+              <stop offset="100%" stopColor="var(--chart-line)" stopOpacity={0.01} />
+            </linearGradient>
+          </defs>
+
+          <CartesianGrid vertical={false} stroke="var(--chart-grid)" strokeWidth={1} />
+
+          <XAxis
+            dataKey="date"
+            tickFormatter={formatAxisDate}
+            tick={{ fill: 'var(--chart-axis)', fontSize: 11 }}
+            axisLine={false}
+            tickLine={false}
+            minTickGap={32}
+          />
+          <YAxis
+            tickFormatter={(v: number) => currencyCompact.format(v)}
+            tick={{ fill: 'var(--chart-axis)', fontSize: 11 }}
+            axisLine={false}
+            tickLine={false}
+            width={56}
+          />
+
+          <Tooltip
+            content={<ChartTooltip />}
+            cursor={{ stroke: 'var(--chart-axis)', strokeWidth: 1 }}
+          />
+
+          <Area
+            type="monotone"
+            dataKey="value"
+            stroke="var(--chart-line)"
+            strokeWidth={2}
+            fill="url(#portfolioValueFill)"
+            activeDot={{ r: 4, stroke: 'var(--chart-line)', strokeWidth: 2, fill: 'white' }}
+            dot={false}
+            isAnimationActive
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/frontend/src/components/deals/CreateDealForm.tsx
+++ b/frontend/src/components/deals/CreateDealForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useForm, useWatch, SubmitHandler } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
@@ -11,6 +11,9 @@ interface CreateDealFormProps {
   onSuccess?: () => void;
   onCancel?: () => void;
 }
+
+const DRAFT_STORAGE_KEY = 'createDealForm.draft';
+const DRAFT_SAVE_DEBOUNCE_MS = 1000;
 
 export const CreateDealForm: React.FC<CreateDealFormProps> = ({ onSuccess, onCancel }) => {
   const t = useTranslations('deals');
@@ -61,6 +64,44 @@ export const CreateDealForm: React.FC<CreateDealFormProps> = ({ onSuccess, onCan
 
   const totalValue = useWatch({ control, name: 'total_value' }) || 0;
   const tokenPrice = useWatch({ control, name: 'token_price' }) || 0;
+  const watchedValues = useWatch({ control });
+
+  const [restoredAt, setRestoredAt] = useState<string | null>(null);
+  const hasHydrated = useRef(false);
+
+  // Restore a saved draft (if any) on mount, before the debounced-save effect
+  // below starts running so we don't immediately clobber it with defaults.
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(DRAFT_STORAGE_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw) as { values: DealFormData; savedAt: string };
+        if (parsed?.values) {
+          reset(parsed.values);
+          setRestoredAt(parsed.savedAt);
+        }
+      }
+    } catch {
+      // Corrupt or inaccessible localStorage — ignore and start fresh.
+    }
+    hasHydrated.current = true;
+  }, [reset]);
+
+  // Persist the draft to localStorage on field change, debounced by 1s.
+  useEffect(() => {
+    if (!hasHydrated.current) return;
+    const timeout = setTimeout(() => {
+      try {
+        localStorage.setItem(
+          DRAFT_STORAGE_KEY,
+          JSON.stringify({ values: watchedValues, savedAt: new Date().toISOString() })
+        );
+      } catch {
+        // Storage full or unavailable — draft persistence is best-effort.
+      }
+    }, DRAFT_SAVE_DEBOUNCE_MS);
+    return () => clearTimeout(timeout);
+  }, [watchedValues]);
 
   const onSubmit: SubmitHandler<DealFormData> = async (data) => {
     // Clean up optional fields
@@ -92,6 +133,11 @@ export const CreateDealForm: React.FC<CreateDealFormProps> = ({ onSuccess, onCan
       });
 
       reset();
+      try {
+        localStorage.removeItem(DRAFT_STORAGE_KEY);
+      } catch {
+        // Best-effort cleanup — nothing to do if storage is unavailable.
+      }
       onSuccess?.();
     } catch (error: any) {
       console.error('Deal creation error:', error);
@@ -101,7 +147,28 @@ export const CreateDealForm: React.FC<CreateDealFormProps> = ({ onSuccess, onCan
   return (
     <div className="bg-white rounded-lg">
       <h2 className="text-2xl font-bold mb-6 text-gray-800">{t('createTitle')}</h2>
-      
+
+      {restoredAt && (
+        <div className="alert-info mb-5">
+          <span>💾</span>
+          <p className="flex-1">
+            {t('draftRestored', {
+              time: new Date(restoredAt).toLocaleTimeString(undefined, {
+                hour: '2-digit',
+                minute: '2-digit',
+              }),
+            })}
+          </p>
+          <button
+            type="button"
+            onClick={() => setRestoredAt(null)}
+            className="text-blue-700 hover:text-blue-900 font-semibold text-xs flex-shrink-0"
+          >
+            {tc('dismiss')}
+          </button>
+        </div>
+      )}
+
       <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
         <div className="flex flex-col">
           <label htmlFor="commodity" className="mb-1 text-sm font-semibold text-gray-700">

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -148,6 +148,7 @@
   },
   "deals": {
     "createTitle": "Create New Trade Deal",
+    "draftRestored": "Restored draft from {time}",
     "commodity": "Commodity Name",
     "quantity": "Quantity",
     "unit": "Unit",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -148,6 +148,7 @@
   },
   "deals": {
     "createTitle": "Créer un nouveau contrat commercial",
+    "draftRestored": "Brouillon restauré depuis {time}",
     "commodity": "Nom de la marchandise",
     "quantity": "Quantité",
     "unit": "Unité",

--- a/frontend/src/messages/pt.json
+++ b/frontend/src/messages/pt.json
@@ -193,6 +193,7 @@
   },
   "deals": {
     "createTitle": "Criar Novo Negócio Comercial",
+    "draftRestored": "Rascunho restaurado de {time}",
     "commodity": "Nome da Mercadoria",
     "quantity": "Quantidade",
     "unit": "Unidade",

--- a/frontend/src/messages/sw.json
+++ b/frontend/src/messages/sw.json
@@ -148,6 +148,7 @@
   },
   "deals": {
     "createTitle": "Unda Mkataba Mpya wa Biashara",
+    "draftRestored": "Rasimu imerejeshwa kutoka {time}",
     "commodity": "Jina la Bidhaa",
     "quantity": "Kiasi",
     "unit": "Kitengo",


### PR DESCRIPTION
## Summary

Implements four frontend feature requests:

- **#274 — Deal draft persistence.** `CreateDealForm` now watches field changes and saves a draft to `localStorage` (debounced 1s), restores it on mount with a dismissible "Restored draft from [time]" banner, and clears the draft on successful submission.
- **#271 — Help Center.** New public page at `/help` with categorized FAQ accordions (Stellar, Investing, Shipping, Security), a deal-lifecycle diagram, and a live search input that filters and highlights matching questions.
- **#273 — Portfolio trend chart.** Added Recharts and a new `PortfolioChart` component: responsive, formatted currency tooltips/axes, and explicit empty/single-point states. Wired into the investor dashboard's Portfolio tab against a derived cumulative-investment trend.
- **#275 — Admin document verification.** New list-detail admin panel (`/dashboard/admin/documents`) with PDF/image preview, approve/reject actions, and a rejection-reason textarea. This required backend support that didn't exist yet, so it also adds:
  - a migration + `Document` entity columns (`verificationStatus`, `rejectionReason`, `reviewedBy`, `reviewedAt`)
  - three admin-only endpoints (`GET /admin/documents`, `POST /admin/documents/:id/verify`, `POST /admin/documents/:id/reject`)
  - matching Next.js proxy routes

## Notes

- New pages live under `[locale]/help` and `[locale]/dashboard/admin/documents` rather than the literal paths in the issue text, since this app's `next-intl` middleware requires routes to live under `[locale]` (matches the existing `transparency`/`dashboard/admin` convention).
- The `GET /admin/documents` endpoint explicitly whitelists the `uploader` relation's columns (id/email/role only) to avoid leaking the full `User` row (password hash, PII) through the join.

## Test plan

- [x] `tsc --noEmit` clean on both frontend and backend for all changed/new files (pre-existing unrelated errors elsewhere are unchanged in count)
- [x] `eslint` clean on all changed/new files
- [x] `jest` — no new failures; full-suite pass/fail counts match baseline exactly (131/106 pre-existing failures unrelated to this change)
- [x] i18n key-parity spec passes across en/fr/pt/sw
- [ ] Manual QA in a running app (DB migration + backend not exercised live in this environment)

Closes #274
Closes #271
Closes #273
Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)