### PR TITLE
feat(monitoring): dashboard alerts for failed escrow payments

### DIFF
--- a/backend/src/auth/admin.controller.ts
+++ b/backend/src/auth/admin.controller.ts
@@ -9,12 +9,15 @@ import {
   Query,
   NotFoundException,
   BadRequestException,
+  ParseIntPipe,
+  DefaultValuePipe,
 } from '@nestjs/common';
 import {
   ApiTags,
   ApiOperation,
   ApiResponse,
   ApiBearerAuth,
+  ApiQuery,
 } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
 import { AuthService } from './auth.service';
@@ -36,6 +39,7 @@ import { TradeDeal } from '../trade-deals/entities/trade-deal.entity';
 import { Document } from '../trade-deals/entities/document.entity';
 import { StellarService } from '../stellar/stellar.service';
 import { AdminAction } from '../database/entities/admin-action.entity';
+import { FailedPaymentsService } from '../escrow/failed-payments.service';
 
 class UpdateUserRoleDto {
   @IsIn(['farmer', 'trader', 'investor', 'company_admin', 'admin'])
@@ -75,6 +79,7 @@ export class AdminController {
   constructor(
     private readonly authService: AuthService,
     private readonly stellarService: StellarService,
+    private readonly failedPaymentsService: FailedPaymentsService,
     @InjectRepository(TradeDeal)
     private readonly tradeDealRepo: Repository<TradeDeal>,
     @InjectRepository(Document)
@@ -269,5 +274,53 @@ export class AdminController {
     );
 
     return { txId };
+  }
+
+  // ── Failed Payment Alerts ─────────────────────────────────────────────────
+
+  /**
+   * GET /admin/payments/failed
+   *
+   * Returns a paginated list of escrow transactions that have status='failed',
+   * ordered by creation date descending. Each entry includes the deal commodity
+   * and error code so admins can quickly triage issues.
+   */
+  @Get('payments/failed')
+  @ApiOperation({
+    summary: 'List failed escrow payment transactions for admin review',
+  })
+  @ApiQuery({ name: 'page', required: false, type: Number, description: 'Page number (default 1)' })
+  @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Items per page (default 20, max 100)' })
+  @ApiResponse({ status: 200, description: 'Paginated list of failed payments' })
+  @ApiResponse({ status: 403, description: 'Forbidden - Admin role required' })
+  async getFailedPayments(
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit: number,
+  ) {
+    return this.failedPaymentsService.getFailedPayments(page, limit);
+  }
+
+  /**
+   * POST /admin/payments/failed/:id/retry
+   *
+   * Manually re-enqueues the `deal.delivered` event for the deal associated
+   * with the failed transaction, allowing the escrow release to be retried.
+   *
+   * Acceptance criterion: "Admins can trigger manual retries directly from the UI."
+   */
+  @Post('payments/failed/:id/retry')
+  @ApiOperation({
+    summary: 'Trigger a manual retry for a failed escrow payment',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Retry event enqueued',
+    schema: { properties: { queued: { type: 'boolean' }, dealId: { type: 'string' } } },
+  })
+  @ApiResponse({ status: 400, description: 'Transaction not in failed state or has no deal' })
+  @ApiResponse({ status: 403, description: 'Forbidden - Admin role required' })
+  @ApiResponse({ status: 404, description: 'Transaction log not found' })
+  async retryFailedPayment(@Param('id') id: string) {
+    return this.failedPaymentsService.retryFailedPayment(id);
   }
 }

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -22,6 +22,7 @@ import { KycCronService } from './kyc-cron.service';
 import { RedisConfig } from '../config/redis.config';
 import { TokenBlocklistService } from './token-blocklist.service';
 import { MfaGuard } from './guards/mfa.guard';
+import { EscrowModule } from '../escrow/escrow.module';
 
 @Module({
   imports: [
@@ -36,6 +37,7 @@ import { MfaGuard } from './guards/mfa.guard';
     QueueModule,
     NotificationsModule,
     PassportModule,
+    EscrowModule,
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],

--- a/backend/src/escrow/entities/transaction-log.entity.ts
+++ b/backend/src/escrow/entities/transaction-log.entity.ts
@@ -1,0 +1,64 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { TradeDeal } from '../../trade-deals/entities/trade-deal.entity';
+import { User } from '../../auth/entities/user.entity';
+
+export type TxStatus = 'pending' | 'success' | 'failed';
+
+/**
+ * Mirrors the `transaction_logs` table created by migration 1745000000000.
+ *
+ * Every Stellar escrow operation (payout, distribution, retry) records a row
+ * here so that admins can query failed payments from a single table and
+ * trigger manual retries via the admin API.
+ */
+@Entity('transaction_logs')
+export class TransactionLog {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  /** Null when the transaction could not be attributed to a specific user. */
+  @Column({ name: 'user_id', type: 'uuid', nullable: true })
+  userId: string | null;
+
+  @ManyToOne(() => User, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'user_id' })
+  user: User | null;
+
+  /** Null if the transaction is not associated with a trade deal. */
+  @Column({ name: 'deal_id', type: 'uuid', nullable: true })
+  dealId: string | null;
+
+  @ManyToOne(() => TradeDeal, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'deal_id' })
+  deal: TradeDeal | null;
+
+  /** Stellar transaction hash (64-char hex). May be null for failed attempts
+   *  that never reached the network. */
+  @Column({ name: 'tx_hash', type: 'text', nullable: true })
+  txHash: string | null;
+
+  /** Raw XDR envelope for replay / audit. May be null for broker-level failures. */
+  @Column({ name: 'xdr_body', type: 'text', nullable: true })
+  xdrBody: string | null;
+
+  /** Current lifecycle status of the transaction. */
+  @Column({
+    type: 'text',
+    default: 'pending',
+  })
+  status: TxStatus;
+
+  /** Machine-readable error code populated when status = 'failed'. */
+  @Column({ name: 'error_code', type: 'text', nullable: true })
+  errorCode: string | null;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+}

--- a/backend/src/escrow/escrow.module.ts
+++ b/backend/src/escrow/escrow.module.ts
@@ -4,16 +4,19 @@ import { EscrowService } from './escrow.service';
 import { EscrowConsumer } from './escrow.consumer';
 import { EscrowDlqModule } from './escrow-dlq.module';
 import { PaymentDistribution } from './entities/payment-distribution.entity';
+import { TransactionLog } from './entities/transaction-log.entity';
 import { TradeDeal } from '../trade-deals/entities/trade-deal.entity';
 import { Investment } from '../investments/entities/investment.entity';
 import { User } from '../auth/entities/user.entity';
 import { StellarModule } from '../stellar/stellar.module';
 import { QueueModule } from '../queue/queue.module';
+import { FailedPaymentsService } from './failed-payments.service';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([
       PaymentDistribution,
+      TransactionLog,
       TradeDeal,
       Investment,
       User,
@@ -23,7 +26,7 @@ import { QueueModule } from '../queue/queue.module';
     EscrowDlqModule,
   ],
   controllers: [EscrowConsumer],
-  providers: [EscrowService],
-  exports: [EscrowService],
+  providers: [EscrowService, FailedPaymentsService],
+  exports: [EscrowService, FailedPaymentsService],
 })
 export class EscrowModule {}

--- a/backend/src/escrow/failed-payments.service.spec.ts
+++ b/backend/src/escrow/failed-payments.service.spec.ts
@@ -1,0 +1,162 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { NotFoundException, BadRequestException } from '@nestjs/common';
+import { FailedPaymentsService } from './failed-payments.service';
+import { TransactionLog } from './entities/transaction-log.entity';
+import { QueueService } from '../queue/queue.service';
+
+const mockTxLogRepo = () => ({
+  findAndCount: jest.fn(),
+  findOne: jest.fn(),
+});
+
+const mockQueueService = () => ({
+  enqueueDealDelivered: jest.fn(),
+});
+
+describe('FailedPaymentsService', () => {
+  let service: FailedPaymentsService;
+  let txLogRepo: jest.Mocked<Repository<TransactionLog>>;
+  let queueService: jest.Mocked<QueueService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FailedPaymentsService,
+        { provide: getRepositoryToken(TransactionLog), useFactory: mockTxLogRepo },
+        { provide: QueueService, useFactory: mockQueueService },
+      ],
+    }).compile();
+
+    service = module.get<FailedPaymentsService>(FailedPaymentsService);
+    txLogRepo = module.get(getRepositoryToken(TransactionLog));
+    queueService = module.get(QueueService);
+  });
+
+  describe('getFailedPayments', () => {
+    it('returns paginated failed transactions', async () => {
+      const mockRows: Partial<TransactionLog>[] = [
+        {
+          id: 'tx-1',
+          dealId: 'deal-1',
+          userId: 'user-1',
+          txHash: 'abc123',
+          errorCode: 'TIMEOUT',
+          createdAt: new Date('2024-01-01'),
+          status: 'failed',
+          deal: { id: 'deal-1', commodity: 'Cocoa' } as any,
+        },
+      ];
+
+      txLogRepo.findAndCount.mockResolvedValue([mockRows as TransactionLog[], 1]);
+
+      const result = await service.getFailedPayments(1, 20);
+
+      expect(txLogRepo.findAndCount).toHaveBeenCalledWith({
+        where: { status: 'failed' },
+        relations: ['deal'],
+        order: { createdAt: 'DESC' },
+        take: 20,
+        skip: 0,
+      });
+
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].id).toBe('tx-1');
+      expect(result.data[0].dealCommodity).toBe('Cocoa');
+      expect(result.meta.total).toBe(1);
+      expect(result.meta.page).toBe(1);
+      expect(result.meta.totalPages).toBe(1);
+    });
+
+    it('caps limit at 100', async () => {
+      txLogRepo.findAndCount.mockResolvedValue([[], 0]);
+      await service.getFailedPayments(1, 500);
+      expect(txLogRepo.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({ take: 100 }),
+      );
+    });
+
+    it('returns empty list when no failed transactions exist', async () => {
+      txLogRepo.findAndCount.mockResolvedValue([[], 0]);
+      const result = await service.getFailedPayments();
+      expect(result.data).toHaveLength(0);
+      expect(result.meta.total).toBe(0);
+      expect(result.meta.totalPages).toBe(0);
+    });
+  });
+
+  describe('getFailedPaymentById', () => {
+    it('returns a failed transaction log', async () => {
+      const mockLog: Partial<TransactionLog> = {
+        id: 'tx-1',
+        status: 'failed',
+        dealId: 'deal-1',
+      };
+      txLogRepo.findOne.mockResolvedValue(mockLog as TransactionLog);
+
+      const result = await service.getFailedPaymentById('tx-1');
+      expect(result.id).toBe('tx-1');
+    });
+
+    it('throws NotFoundException when transaction does not exist', async () => {
+      txLogRepo.findOne.mockResolvedValue(null);
+      await expect(service.getFailedPaymentById('missing-id')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('throws BadRequestException for non-failed transactions', async () => {
+      const mockLog: Partial<TransactionLog> = {
+        id: 'tx-1',
+        status: 'success',
+      };
+      txLogRepo.findOne.mockResolvedValue(mockLog as TransactionLog);
+      await expect(service.getFailedPaymentById('tx-1')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+
+  describe('retryFailedPayment', () => {
+    it('enqueues a deal.delivered event for the associated deal', async () => {
+      const mockLog: Partial<TransactionLog> = {
+        id: 'tx-1',
+        status: 'failed',
+        dealId: 'deal-abc',
+        deal: null,
+        user: null,
+      };
+      txLogRepo.findOne.mockResolvedValue(mockLog as TransactionLog);
+      queueService.enqueueDealDelivered.mockResolvedValue(undefined);
+
+      const result = await service.retryFailedPayment('tx-1');
+
+      expect(queueService.enqueueDealDelivered).toHaveBeenCalledWith('deal-abc');
+      expect(result).toEqual({ queued: true, dealId: 'deal-abc' });
+    });
+
+    it('throws BadRequestException when transaction has no associated deal', async () => {
+      const mockLog: Partial<TransactionLog> = {
+        id: 'tx-1',
+        status: 'failed',
+        dealId: null,
+        deal: null,
+        user: null,
+      };
+      txLogRepo.findOne.mockResolvedValue(mockLog as TransactionLog);
+
+      await expect(service.retryFailedPayment('tx-1')).rejects.toThrow(
+        BadRequestException,
+      );
+      expect(queueService.enqueueDealDelivered).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when transaction does not exist', async () => {
+      txLogRepo.findOne.mockResolvedValue(null);
+      await expect(service.retryFailedPayment('missing')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+});

--- a/backend/src/escrow/failed-payments.service.ts
+++ b/backend/src/escrow/failed-payments.service.ts
@@ -1,0 +1,135 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { TransactionLog } from './entities/transaction-log.entity';
+import { QueueService } from '../queue/queue.service';
+
+export interface FailedPaymentSummary {
+  id: string;
+  dealId: string | null;
+  userId: string | null;
+  txHash: string | null;
+  errorCode: string | null;
+  createdAt: Date;
+  /** Expose deal commodity for UI convenience when relation is loaded */
+  dealCommodity?: string | null;
+}
+
+export interface PaginatedFailedPayments {
+  data: FailedPaymentSummary[];
+  meta: {
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+  };
+}
+
+@Injectable()
+export class FailedPaymentsService {
+  private readonly logger = new Logger(FailedPaymentsService.name);
+
+  constructor(
+    @InjectRepository(TransactionLog)
+    private readonly txLogRepo: Repository<TransactionLog>,
+    private readonly queueService: QueueService,
+  ) {}
+
+  /**
+   * Return a paginated list of transaction_logs rows with status = 'failed',
+   * ordered newest-first.  Loads the associated trade deal so the UI can
+   * display the commodity name.
+   */
+  async getFailedPayments(
+    page = 1,
+    limit = 20,
+  ): Promise<PaginatedFailedPayments> {
+    const safeLimit = Math.min(Math.max(1, limit), 100);
+    const safePage = Math.max(1, page);
+    const skip = (safePage - 1) * safeLimit;
+
+    const [rows, total] = await this.txLogRepo.findAndCount({
+      where: { status: 'failed' },
+      relations: ['deal'],
+      order: { createdAt: 'DESC' },
+      take: safeLimit,
+      skip,
+    });
+
+    const data: FailedPaymentSummary[] = rows.map((row) => ({
+      id: row.id,
+      dealId: row.dealId,
+      userId: row.userId,
+      txHash: row.txHash,
+      errorCode: row.errorCode,
+      createdAt: row.createdAt,
+      dealCommodity: row.deal?.commodity ?? null,
+    }));
+
+    return {
+      data,
+      meta: {
+        total,
+        page: safePage,
+        limit: safeLimit,
+        totalPages: Math.ceil(total / safeLimit),
+      },
+    };
+  }
+
+  /**
+   * Fetch a single failed transaction log by ID.
+   * Throws NotFoundException if not found or not in 'failed' status.
+   */
+  async getFailedPaymentById(id: string): Promise<TransactionLog> {
+    const log = await this.txLogRepo.findOne({
+      where: { id },
+      relations: ['deal', 'user'],
+    });
+
+    if (!log) {
+      throw new NotFoundException(`Transaction log ${id} not found`);
+    }
+
+    if (log.status !== 'failed') {
+      throw new BadRequestException(
+        `Transaction ${id} is not in failed state (current: ${log.status})`,
+      );
+    }
+
+    return log;
+  }
+
+  /**
+   * Enqueue a manual retry for a failed transaction by re-publishing
+   * a `deal.delivered` event for the associated trade deal.
+   *
+   * Acceptance criterion: "Admins can trigger manual retries directly from the UI."
+   */
+  async retryFailedPayment(id: string): Promise<{ queued: boolean; dealId: string }> {
+    const log = await this.getFailedPaymentById(id);
+
+    if (!log.dealId) {
+      throw new BadRequestException(
+        `Transaction ${id} has no associated deal — cannot retry automatically`,
+      );
+    }
+
+    this.logger.log(
+      `Admin-triggered retry for transaction ${id} (deal ${log.dealId})`,
+    );
+
+    await this.queueService.enqueueDealDelivered(log.dealId);
+
+    this.logger.log(
+      `Retry event published for deal ${log.dealId} (triggered from tx log ${id})`,
+    );
+
+    return { queued: true, dealId: log.dealId };
+  }
+}

--- a/frontend/src/app/[locale]/dashboard/admin/page.tsx
+++ b/frontend/src/app/[locale]/dashboard/admin/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { apiClient, User, getStoredToken } from '@/lib/api';
 import DashboardLayout from '@/components/DashboardLayout';
@@ -10,6 +10,22 @@ import { useToast } from '@/components/ui/ToastProvider';
 interface AdminUser {
   id: string; email: string; role: string; kycStatus: string;
   country: string; createdAt: string; walletAddress?: string | null;
+}
+
+/** Shape returned by GET /admin/payments/failed */
+interface FailedPayment {
+  id: string;
+  dealId: string | null;
+  userId: string | null;
+  txHash: string | null;
+  errorCode: string | null;
+  createdAt: string;
+  dealCommodity: string | null;
+}
+
+interface PaginatedFailedPayments {
+  data: FailedPayment[];
+  meta: { total: number; page: number; limit: number; totalPages: number };
 }
 
 const ROLE_BADGE: Record<string, string> = {
@@ -26,9 +42,16 @@ export default function AdminDashboard() {
   const [user, setUser] = useState<User | null>(null);
   const [users, setUsers] = useState<AdminUser[]>([]);
   const [loading, setLoading] = useState(true);
-  const [tab, setTab] = useState<'overview' | 'users' | 'kyc' | 'blockchain'>('overview');
+  const [tab, setTab] = useState<'overview' | 'users' | 'kyc' | 'blockchain' | 'payments'>('overview');
   const [search, setSearch] = useState('');
   const [actionId, setActionId] = useState<string | null>(null);
+
+  // ── Failed Payments State ─────────────────────────────────────────────────
+  const [failedPayments, setFailedPayments] = useState<FailedPayment[]>([]);
+  const [failedPaymentsMeta, setFailedPaymentsMeta] = useState<PaginatedFailedPayments['meta'] | null>(null);
+  const [failedPaymentsLoading, setFailedPaymentsLoading] = useState(false);
+  const [failedPaymentsPage, setFailedPaymentsPage] = useState(1);
+  const [retryingId, setRetryingId] = useState<string | null>(null);
 
   useEffect(() => {
     (async () => {
@@ -50,6 +73,56 @@ export default function AdminDashboard() {
       if (res.ok) { const d = await res.json(); setUsers(d.users ?? d ?? []); }
     } catch {}
     setLoading(false);
+  };
+
+  const loadFailedPayments = useCallback(async (page = 1) => {
+    setFailedPaymentsLoading(true);
+    try {
+      const token = getStoredToken();
+      const res = await fetch(`/api/admin/payments/failed?page=${page}&limit=20`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.ok) {
+        const d: PaginatedFailedPayments = await res.json();
+        setFailedPayments(d.data ?? []);
+        setFailedPaymentsMeta(d.meta ?? null);
+        setFailedPaymentsPage(page);
+      } else {
+        toast('Failed to load payment alerts', 'error');
+      }
+    } catch {
+      toast('Could not fetch payment data', 'error');
+    }
+    setFailedPaymentsLoading(false);
+  }, [toast]);
+
+  // Load failed payments when the payments tab is first selected
+  useEffect(() => {
+    if (tab === 'payments' && failedPayments.length === 0 && !failedPaymentsLoading) {
+      loadFailedPayments(1);
+    }
+  }, [tab, failedPayments.length, failedPaymentsLoading, loadFailedPayments]);
+
+  const retryPayment = async (txId: string) => {
+    setRetryingId(txId);
+    try {
+      const token = getStoredToken();
+      const res = await fetch(`/api/admin/payments/failed/${txId}/retry`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.ok) {
+        toast('Retry enqueued successfully ✅', 'success');
+        // Refresh the list after a short delay so the user sees updated state
+        setTimeout(() => loadFailedPayments(failedPaymentsPage), 1000);
+      } else {
+        const d = await res.json();
+        toast(d.message ?? 'Retry failed', 'error');
+      }
+    } catch {
+      toast('Request failed', 'error');
+    }
+    setRetryingId(null);
   };
 
   const approveKyc = async (userId: string) => {
@@ -109,15 +182,20 @@ export default function AdminDashboard() {
 
         {/* Tabs */}
         <div className="flex gap-1 bg-slate-100 rounded-xl p-1 w-fit">
-          {(['overview', 'users', 'kyc', 'blockchain'] as const).map(t => (
+          {(['overview', 'users', 'kyc', 'blockchain', 'payments'] as const).map(t => (
             <button key={t} onClick={() => setTab(t)}
               className={`px-4 py-2 rounded-lg text-sm font-semibold capitalize transition-all ${
                 tab === t ? 'bg-white shadow-sm text-slate-900' : 'text-slate-500 hover:text-slate-700'
               }`}>
-              {t === 'blockchain' ? '⛓ Blockchain' : t}
+              {t === 'blockchain' ? '⛓ Blockchain' : t === 'payments' ? '⚠️ Payments' : t}
               {t === 'kyc' && pendingKyc.length > 0 && (
                 <span className="ml-1.5 bg-red-500 text-white text-[10px] rounded-full px-1.5 py-0.5 font-bold">
                   {pendingKyc.length}
+                </span>
+              )}
+              {t === 'payments' && (failedPaymentsMeta?.total ?? 0) > 0 && (
+                <span className="ml-1.5 bg-red-500 text-white text-[10px] rounded-full px-1.5 py-0.5 font-bold">
+                  {failedPaymentsMeta!.total}
                 </span>
               )}
             </button>
@@ -297,8 +375,242 @@ export default function AdminDashboard() {
         {tab === 'blockchain' && (
           <BlockchainTab token={getStoredToken() ?? ''} toast={toast} />
         )}
+
+        {/* Failed Payments tab */}
+        {tab === 'payments' && (
+          <FailedPaymentsTab
+            payments={failedPayments}
+            meta={failedPaymentsMeta}
+            loading={failedPaymentsLoading}
+            retryingId={retryingId}
+            page={failedPaymentsPage}
+            onRetry={retryPayment}
+            onPageChange={loadFailedPayments}
+            onRefresh={() => loadFailedPayments(failedPaymentsPage)}
+          />
+        )}
       </div>
     </DashboardLayout>
+  );
+}
+
+// ── Failed Payments Tab ───────────────────────────────────────────────────────
+
+interface FailedPaymentsTabProps {
+  payments: FailedPayment[];
+  meta: PaginatedFailedPayments['meta'] | null;
+  loading: boolean;
+  retryingId: string | null;
+  page: number;
+  onRetry: (txId: string) => void;
+  onPageChange: (page: number) => void;
+  onRefresh: () => void;
+}
+
+function FailedPaymentsTab({
+  payments,
+  meta,
+  loading,
+  retryingId,
+  page,
+  onRetry,
+  onPageChange,
+  onRefresh,
+}: FailedPaymentsTabProps) {
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="section-title">Failed Payment Alerts</h2>
+          <p className="text-sm text-slate-500 mt-1">
+            Escrow transactions that failed and require admin attention.
+          </p>
+        </div>
+        <button
+          onClick={onRefresh}
+          disabled={loading}
+          className="btn-secondary flex items-center gap-2 text-sm px-4 py-2"
+          aria-label="Refresh failed payments list"
+        >
+          <svg
+            className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+            />
+          </svg>
+          {loading ? 'Loading…' : 'Refresh'}
+        </button>
+      </div>
+
+      {/* Summary badge */}
+      {meta && meta.total > 0 && (
+        <div className="flex items-center gap-3 p-4 bg-red-50 border border-red-200 rounded-xl">
+          <div className="w-10 h-10 rounded-xl bg-red-100 flex items-center justify-center text-xl" aria-hidden="true">
+            ⚠️
+          </div>
+          <div>
+            <p className="font-semibold text-red-800 text-sm">
+              {meta.total} failed payment{meta.total !== 1 ? 's' : ''} require attention
+            </p>
+            <p className="text-xs text-red-600 mt-0.5">
+              Review each transaction below and trigger a retry if appropriate.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Loading skeleton */}
+      {loading && (
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="card h-20 skeleton" />
+          ))}
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!loading && payments.length === 0 && (
+        <div className="card p-14 text-center">
+          <div className="w-16 h-16 rounded-3xl bg-emerald-50 flex items-center justify-center text-3xl mx-auto mb-5" aria-hidden="true">
+            ✅
+          </div>
+          <h3 className="font-bold text-slate-900 text-lg mb-2">No failed payments</h3>
+          <p className="text-slate-500 text-sm">
+            All escrow transactions are processing normally.
+          </p>
+        </div>
+      )}
+
+      {/* Payments table */}
+      {!loading && payments.length > 0 && (
+        <div className="table-wrapper">
+          <div className="overflow-x-auto">
+            <table className="w-full" aria-label="Failed escrow payments">
+              <thead className="table-head">
+                <tr>
+                  {['Transaction ID', 'Deal / Commodity', 'Error Code', 'TX Hash', 'Date', 'Action'].map((h) => (
+                    <th key={h} className="table-th" scope="col">{h}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {payments.map((payment) => (
+                  <tr key={payment.id} className="table-row">
+                    {/* Transaction ID */}
+                    <td className="table-td font-mono text-xs text-slate-600" title={payment.id}>
+                      {payment.id.substring(0, 8)}…
+                    </td>
+
+                    {/* Deal / Commodity */}
+                    <td className="table-td">
+                      {payment.dealId ? (
+                        <div>
+                          <p className="text-sm font-medium text-slate-900">
+                            {payment.dealCommodity ?? 'Unknown commodity'}
+                          </p>
+                          <p className="font-mono text-[10px] text-slate-400" title={payment.dealId}>
+                            {payment.dealId.substring(0, 8)}…
+                          </p>
+                        </div>
+                      ) : (
+                        <span className="text-slate-400 text-sm italic">No deal linked</span>
+                      )}
+                    </td>
+
+                    {/* Error Code */}
+                    <td className="table-td">
+                      {payment.errorCode ? (
+                        <span className="badge-red font-mono text-xs">
+                          {payment.errorCode}
+                        </span>
+                      ) : (
+                        <span className="text-slate-400 text-xs">—</span>
+                      )}
+                    </td>
+
+                    {/* TX Hash */}
+                    <td className="table-td font-mono text-xs text-slate-500" title={payment.txHash ?? ''}>
+                      {payment.txHash ? `${payment.txHash.substring(0, 12)}…` : '—'}
+                    </td>
+
+                    {/* Date */}
+                    <td className="table-td text-xs text-slate-400">
+                      <time dateTime={payment.createdAt}>
+                        {new Date(payment.createdAt).toLocaleString()}
+                      </time>
+                    </td>
+
+                    {/* Retry action */}
+                    <td className="table-td">
+                      <button
+                        disabled={retryingId === payment.id || !payment.dealId}
+                        onClick={() => onRetry(payment.id)}
+                        title={!payment.dealId ? 'Cannot retry: no deal linked' : 'Trigger manual retry'}
+                        aria-label={`Retry transaction ${payment.id.substring(0, 8)}`}
+                        className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold bg-amber-50 text-amber-700 border border-amber-200 hover:bg-amber-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                      >
+                        {retryingId === payment.id ? (
+                          <>
+                            <svg className="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+                              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                            </svg>
+                            Retrying…
+                          </>
+                        ) : (
+                          <>
+                            <svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24" aria-hidden="true">
+                              <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                            </svg>
+                            Retry
+                          </>
+                        )}
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Pagination */}
+          {meta && meta.totalPages > 1 && (
+            <div className="flex items-center justify-between px-5 py-4 border-t border-slate-100">
+              <p className="text-xs text-slate-500">
+                Showing page {meta.page} of {meta.totalPages} ({meta.total} total)
+              </p>
+              <div className="flex gap-2">
+                <button
+                  disabled={page <= 1}
+                  onClick={() => onPageChange(page - 1)}
+                  aria-label="Previous page"
+                  className="px-3 py-1.5 rounded-lg text-xs font-semibold border border-slate-200 text-slate-600 hover:bg-slate-50 disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                  ← Prev
+                </button>
+                <button
+                  disabled={page >= meta.totalPages}
+                  onClick={() => onPageChange(page + 1)}
+                  aria-label="Next page"
+                  className="px-3 py-1.5 rounded-lg text-xs font-semibold border border-slate-200 text-slate-600 hover:bg-slate-50 disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                  Next →
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/frontend/src/app/api/admin/payments/failed/[txId]/retry/route.ts
+++ b/frontend/src/app/api/admin/payments/failed/[txId]/retry/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { fetchBackend } from '@/config/backend';
+
+/**
+ * POST /api/admin/payments/failed/[txId]/retry
+ *
+ * Proxies to the backend POST /admin/payments/failed/:id/retry endpoint which
+ * re-enqueues the `deal.delivered` event for the associated trade deal,
+ * triggering another escrow release attempt.
+ *
+ * Requires a valid admin JWT via Authorization: Bearer <token>.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { txId: string } },
+) {
+  try {
+    const authHeader = request.headers.get('authorization');
+
+    const response = await fetchBackend(
+      `/admin/payments/failed/${params.txId}/retry`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: authHeader || '',
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+
+    const data = await response.json();
+    if (!response.ok) {
+      return NextResponse.json(data, { status: response.status });
+    }
+    return NextResponse.json(data);
+  } catch (error: any) {
+    if (error?.isBackendUnreachable) {
+      return NextResponse.json(
+        { message: 'Backend service is unavailable' },
+        { status: 503 },
+      );
+    }
+    return NextResponse.json(
+      { message: 'Internal server error' },
+      { status: 500 },
+    );
+  }
+}

--- a/frontend/src/app/api/admin/payments/failed/route.ts
+++ b/frontend/src/app/api/admin/payments/failed/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { fetchBackend } from '@/config/backend';
+
+/**
+ * GET /api/admin/payments/failed?page=1&limit=20
+ *
+ * Proxies to the backend GET /admin/payments/failed endpoint which returns a
+ * paginated list of escrow transaction_logs with status='failed'.
+ *
+ * Requires a valid admin JWT via Authorization: Bearer <token>.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const authHeader = request.headers.get('authorization');
+    const { searchParams } = request.nextUrl;
+    const page = searchParams.get('page') ?? '1';
+    const limit = searchParams.get('limit') ?? '20';
+
+    const response = await fetchBackend(
+      `/admin/payments/failed?page=${page}&limit=${limit}`,
+      { headers: { Authorization: authHeader || '' } },
+    );
+
+    const data = await response.json();
+    if (!response.ok) {
+      return NextResponse.json(data, { status: response.status });
+    }
+    return NextResponse.json(data);
+  } catch (error: any) {
+    if (error?.isBackendUnreachable) {
+      return NextResponse.json(
+        { message: 'Backend service is unavailable' },
+        { status: 503 },
+      );
+    }
+    return NextResponse.json(
+      { message: 'Internal server error' },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Implements dashboard alerts for failed escrow payments so admins can review and remediate payment failures without digging into logs.

## Changes

### Backend
- **`TransactionLog` entity** — mirrors `transaction_logs` table (uuid PK, deal/user relations, status, error_code, tx_hash, xdr_body)
- **`FailedPaymentsService`** — paginated query of `transaction_logs` where `status = 'failed'`, ordered newest-first; manual retry via re-enqueueing `deal.delivered` event
- **`AdminController`** — two new admin-only endpoints:
  - `GET /admin/payments/failed?page=&limit=` — paginated list with deal commodity
  - `POST /admin/payments/failed/:id/retry` — enqueue manual retry
- **`EscrowModule` / `AuthModule`** — wired `FailedPaymentsService` and `TransactionLog` repository

### Frontend
- **Next.js proxy routes** — `GET /api/admin/payments/failed` and `POST /api/admin/payments/failed/[txId]/retry`
- **`FailedPaymentsTab` component** — new tab on the admin dashboard (`⚠️ Payments`) with:
  - Paginated review panel listing all failed transactions
  - Per-row manual retry button with loading/disabled states
  - Red badge counter on the tab when failures are present
  - Loading skeleton, empty state, and pagination controls
  - Accessible markup (`aria-label`, `scope`, `dateTime`, `title`)

### Tests
- 9 unit tests for `FailedPaymentsService` covering happy paths and all error branches — all passing
- 43 existing admin panel access-control tests — all still passing
- TypeScript compiles clean (`tsc --noEmit`)

## Acceptance Criteria

- [x] Payment exceptions are listed in a review panel
- [x] Admins can trigger manual retries directly from the UI

## Issue References

Closes #731
Closes #732
Closes #733
Closes #734