### PR TITLE
perf(soroban): minimise compiled WASM sizes (#697)

### DIFF
--- a/blockchain/Cargo.toml
+++ b/blockchain/Cargo.toml
@@ -8,6 +8,21 @@ members = [
 resolver = "2"
 
 [profile.release]
+# ── WASM size optimisation (#697) ────────────────────────────────────────────
+# Stellar charges storage fees proportional to WASM binary size, so we
+# minimise every byte.  These settings target <15 KB per compiled contract.
+#
+#   opt-level = "z"   — optimise for smallest code size (vs "s" or "3")
+#   lto        = true — full link-time optimisation; eliminates dead code
+#                       across the entire crate graph at link time
+#   codegen-units = 1 — single CGU is required for LTO to be maximally
+#                       effective (multiple CGUs would limit inlining scope)
+#   panic = "abort"   — replaces panic unwinding machinery with a single
+#                       wasm `unreachable` instruction, saving ~5–10 KB
+#   strip = "symbols" — removes symbol names from the final binary
+#
+# After cargo build, run wasm-opt -Oz (see blockchain/scripts/build.sh or
+# blockchain/scripts/deploy.sh) for an additional 5–20% size reduction.
 opt-level = "z"
 overflow-checks = true
 debug = 0

--- a/blockchain/scripts/build.sh
+++ b/blockchain/scripts/build.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# AgriFi Soroban Contract Build Script
+#
+# Compiles all contracts to WASM and runs wasm-opt -Oz to minimise binary
+# sizes, targeting the <15 KB acceptance threshold per contract.
+#
+# Cargo release profile settings (blockchain/Cargo.toml):
+#   opt-level = "z"   — optimise for size (smallest code)
+#   lto        = true — full link-time optimisation across crates
+#   codegen-units = 1 — single codegen unit for maximum LTO effectiveness
+#   panic = "abort"   — remove panic unwinding machinery
+#   strip = "symbols" — strip debug symbols from output
+#
+# wasm-opt -Oz applies Binaryen's binary-size-focused passes on top of rustc's
+# output, typically reducing size by an additional 5–20%.
+#
+# Prerequisites (local build):
+#   - Rust with wasm32-unknown-unknown target:
+#       rustup target add wasm32-unknown-unknown
+#   - wasm-opt from Binaryen:
+#       cargo install wasm-opt  OR  brew install binaryen  OR download from
+#       https://github.com/WebAssembly/binaryen/releases
+#
+# Usage:
+#   ./scripts/build.sh [--check-size]
+#
+#   --check-size  Print sizes and exit with code 1 if any contract exceeds 15 KB
+# ─────────────────────────────────────────────────────────────────────────────
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BLOCKCHAIN_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+SIZE_LIMIT_BYTES=15360  # 15 KB
+CHECK_SIZE=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --check-size) CHECK_SIZE=true ;;
+    *) echo "Unknown argument: $arg"; exit 1 ;;
+  esac
+done
+
+# ── Validate toolchain ────────────────────────────────────────────────────────
+if ! rustup target list --installed | grep -q "wasm32-unknown-unknown"; then
+  echo "❌ wasm32-unknown-unknown target not installed."
+  echo "   Run: rustup target add wasm32-unknown-unknown"
+  exit 1
+fi
+
+if ! command -v wasm-opt &>/dev/null; then
+  echo "❌ wasm-opt not found. Install Binaryen:"
+  echo "   cargo install wasm-opt"
+  echo "   brew install binaryen"
+  echo "   https://github.com/WebAssembly/binaryen/releases"
+  exit 1
+fi
+
+# ── Build ─────────────────────────────────────────────────────────────────────
+echo "📦 Building contracts (release profile: opt-level=z, lto, panic=abort)..."
+cd "$BLOCKCHAIN_DIR"
+cargo build --target wasm32-unknown-unknown --release
+
+WASM_DIR="$BLOCKCHAIN_DIR/target/wasm32-unknown-unknown/release"
+
+# ── wasm-opt post-processing ──────────────────────────────────────────────────
+echo ""
+echo "⚙️  Running wasm-opt -Oz on compiled contracts..."
+echo "─────────────────────────────────────────────────"
+printf "%-40s %10s %10s %8s\n" "Contract" "Before" "After" "Saving"
+echo "─────────────────────────────────────────────────"
+
+# Track failures for --check-size
+OVERSIZED=()
+
+for wasm in "$WASM_DIR"/*.wasm; do
+  # Skip test/deps artifacts (only process contracts that have a matching src/ dir)
+  name="$(basename "$wasm" .wasm)"
+
+  # Skip *-test.wasm and similar non-contract artifacts
+  [[ "$name" == *test* ]] && continue
+  [[ "$name" == *deps* ]] && continue
+
+  original_bytes=$(wc -c < "$wasm")
+
+  # -Oz: size-focused passes; --strip-debug: remove DWARF; --strip-producers: remove tool metadata
+  wasm-opt -Oz --strip-debug --strip-producers "$wasm" -o "$wasm"
+
+  optimised_bytes=$(wc -c < "$wasm")
+  saved=$((original_bytes - optimised_bytes))
+  saved_pct=$(( saved * 100 / original_bytes ))
+
+  optimised_kb=$(echo "scale=1; $optimised_bytes / 1024" | bc)
+
+  printf "%-40s %10s %10s %7s%%\n" \
+    "$name.wasm" \
+    "$(numfmt --to=iec-i --suffix=B --format="%.1f" "$original_bytes" 2>/dev/null || echo "${original_bytes}B")" \
+    "$(numfmt --to=iec-i --suffix=B --format="%.1f" "$optimised_bytes" 2>/dev/null || echo "${optimised_bytes}B")" \
+    "$saved_pct"
+
+  if $CHECK_SIZE && [ "$optimised_bytes" -gt "$SIZE_LIMIT_BYTES" ]; then
+    OVERSIZED+=("$name (${optimised_kb} KB > 15 KB limit)")
+  fi
+done
+
+echo "─────────────────────────────────────────────────"
+echo ""
+echo "✅ Build complete. Optimised WASMs in:"
+echo "   $WASM_DIR"
+
+if $CHECK_SIZE; then
+  if [ ${#OVERSIZED[@]} -gt 0 ]; then
+    echo ""
+    echo "❌ The following contracts exceed the 15 KB size limit:"
+    for item in "${OVERSIZED[@]}"; do
+      echo "   • $item"
+    done
+    exit 1
+  else
+    echo "✅ All contracts are within the 15 KB size limit."
+  fi
+fi

--- a/blockchain/scripts/deploy.sh
+++ b/blockchain/scripts/deploy.sh
@@ -36,15 +36,36 @@ STELLAR_CLI_IMAGE="stellar/stellar-cli:latest"
 
 echo "🚀 Starting AgriFi Deployment Pipeline ($NETWORK)"
 
-# ── 1. Compilation ────────────────────────────────────────────────────────────
-echo "📦 Step 1: Compiling contracts inside Docker..."
+# ── 1. Compilation + WASM optimisation ───────────────────────────────────────
+echo "📦 Step 1: Compiling contracts and optimising WASM inside Docker..."
 docker run --rm \
   -v "$BLOCKCHAIN_DIR":/workspace \
   -w /workspace \
   "$RUST_IMAGE" \
-  bash -c "apt-get update && apt-get install -y clang && \
-           rustup target add wasm32-unknown-unknown && \
-           cargo build --target wasm32-unknown-unknown --release"
+  bash -c "
+    set -euo pipefail
+    apt-get update -qq && apt-get install -y --no-install-recommends clang curl xz-utils
+
+    # Install binaryen (wasm-opt) — use a pre-built release for speed
+    BINARYEN_VER=117
+    curl -fsSL https://github.com/WebAssembly/binaryen/releases/download/version_\${BINARYEN_VER}/binaryen-version_\${BINARYEN_VER}-x86_64-linux.tar.gz \
+      | tar -xz --strip-components=2 -C /usr/local/bin binaryen-version_\${BINARYEN_VER}/bin/wasm-opt
+
+    rustup target add wasm32-unknown-unknown
+
+    # Compile with workspace release profile (opt-level=z, lto, codegen-units=1, panic=abort)
+    cargo build --target wasm32-unknown-unknown --release
+
+    # Post-process each WASM with wasm-opt -Oz for further binary size reduction
+    WASM_DIR=target/wasm32-unknown-unknown/release
+    for wasm in \${WASM_DIR}/*.wasm; do
+      [ -f \"\${wasm}\" ] || continue
+      original_size=\$(wc -c < \"\${wasm}\")
+      wasm-opt -Oz --strip-debug --strip-producers \"\${wasm}\" -o \"\${wasm}\"
+      optimised_size=\$(wc -c < \"\${wasm}\")
+      echo \"  ✅ \$(basename \"\${wasm}\"): \${original_size} → \${optimised_size} bytes\"
+    done
+  "
 
 WASM_DIR="$BLOCKCHAIN_DIR/target/wasm32-unknown-unknown/release"
 


### PR DESCRIPTION
Reduce Stellar storage fees by aggressively optimising WASM binary size.

Cargo release profile (blockchain/Cargo.toml):
  - opt-level = "z"    — smallest code size optimisation
  - lto = true          — full link-time optimisation (dead code removal)
  - codegen-units = 1   — required for LTO to be fully effective
  - panic = "abort"    — replaces unwinding machinery (~5–10 KB saving)
  - strip = "symbols"  — strips all debug symbol names

Post-compilation wasm-opt step:
  - deploy.sh: installs binaryen wasm-opt inside Docker build container and runs wasm-opt -Oz --strip-debug --strip-producers on each contract WASM immediately after cargo build; reports before/after byte counts
  - build.sh (new): standalone local-dev build script with the same wasm-opt step; --check-size flag exits with code 1 if any contract exceeds the 15 KB acceptance threshold (suitable for CI gates)

All four contracts (farm_campaign, revenue_distributor, project_factory, marketplace_settlement) are compiled with these settings via the workspace Cargo.toml profile, requiring no changes to individual contract manifests.

Closes #697